### PR TITLE
Add helmet to server.js, add express.json middleware to server.js, install dev dependencies

### DIFF
--- a/backend/node_modules/.package-lock.json
+++ b/backend/node_modules/.package-lock.json
@@ -96,6 +96,18 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -261,6 +273,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/helmet": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-6.0.1.tgz",
+      "integrity": "sha512-8wo+VdQhTMVBMCITYZaGTbE4lvlthelPYSvoyNvk4RECTmrVjMerp9RfUOQXZWLvCcAn1pKj7ZRxK4lI9Alrcw==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -362,6 +382,14 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {

--- a/backend/node_modules/cors/CONTRIBUTING.md
+++ b/backend/node_modules/cors/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# contributing to `cors`
+
+CORS is a node.js package for providing a [connect](http://www.senchalabs.org/connect/)/[express](http://expressjs.com/) middleware that can be used to enable [CORS](http://en.wikipedia.org/wiki/Cross-origin_resource_sharing) with various options. Learn more about the project in [the README](README.md).
+
+## The CORS Spec
+
+[http://www.w3.org/TR/cors/](http://www.w3.org/TR/cors/)
+
+## Pull Requests Welcome
+
+* Include `'use strict';` in every javascript file.
+* 2 space indentation.
+* Please run the testing steps below before submitting.
+
+## Testing
+
+```bash
+$ npm install
+$ npm test
+```
+
+## Interactive Testing Harness
+
+[http://node-cors-client.herokuapp.com](http://node-cors-client.herokuapp.com)
+
+Related git repositories:
+
+* [https://github.com/TroyGoode/node-cors-server](https://github.com/TroyGoode/node-cors-server)
+* [https://github.com/TroyGoode/node-cors-client](https://github.com/TroyGoode/node-cors-client)
+
+## License
+
+[MIT License](http://www.opensource.org/licenses/mit-license.php)

--- a/backend/node_modules/cors/HISTORY.md
+++ b/backend/node_modules/cors/HISTORY.md
@@ -1,0 +1,58 @@
+2.8.5 / 2018-11-04
+==================
+
+  * Fix setting `maxAge` option to `0`
+
+2.8.4 / 2017-07-12
+==================
+
+  * Work-around Safari bug in default pre-flight response
+
+2.8.3 / 2017-03-29
+==================
+
+  * Fix error when options delegate missing `methods` option
+
+2.8.2 / 2017-03-28
+==================
+
+  * Fix error when frozen options are passed
+  * Send "Vary: Origin" when using regular expressions
+  * Send "Vary: Access-Control-Request-Headers" when dynamic `allowedHeaders`
+
+2.8.1 / 2016-09-08
+==================
+
+This release only changed documentation.
+
+2.8.0 / 2016-08-23
+==================
+
+  * Add `optionsSuccessStatus` option
+
+2.7.2 / 2016-08-23
+==================
+
+  * Fix error when Node.js running in strict mode
+
+2.7.1 / 2015-05-28
+==================
+
+  * Move module into expressjs organization
+
+2.7.0 / 2015-05-28
+==================
+
+  * Allow array of matching condition as `origin` option
+  * Allow regular expression as `origin` option
+
+2.6.1 / 2015-05-28
+==================
+
+  * Update `license` in package.json
+
+2.6.0 / 2015-04-27
+==================
+
+  * Add `preflightContinue` option
+  * Fix "Vary: Origin" header added for "*"

--- a/backend/node_modules/cors/LICENSE
+++ b/backend/node_modules/cors/LICENSE
@@ -1,0 +1,22 @@
+(The MIT License)
+
+Copyright (c) 2013 Troy Goode <troygoode@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/backend/node_modules/cors/README.md
+++ b/backend/node_modules/cors/README.md
@@ -1,0 +1,243 @@
+# cors
+
+[![NPM Version][npm-image]][npm-url]
+[![NPM Downloads][downloads-image]][downloads-url]
+[![Build Status][travis-image]][travis-url]
+[![Test Coverage][coveralls-image]][coveralls-url]
+
+CORS is a node.js package for providing a [Connect](http://www.senchalabs.org/connect/)/[Express](http://expressjs.com/) middleware that can be used to enable [CORS](http://en.wikipedia.org/wiki/Cross-origin_resource_sharing) with various options.
+
+**[Follow me (@troygoode) on Twitter!](https://twitter.com/intent/user?screen_name=troygoode)**
+
+* [Installation](#installation)
+* [Usage](#usage)
+  * [Simple Usage](#simple-usage-enable-all-cors-requests)
+  * [Enable CORS for a Single Route](#enable-cors-for-a-single-route)
+  * [Configuring CORS](#configuring-cors)
+  * [Configuring CORS Asynchronously](#configuring-cors-asynchronously)
+  * [Enabling CORS Pre-Flight](#enabling-cors-pre-flight)
+* [Configuration Options](#configuration-options)
+* [Demo](#demo)
+* [License](#license)
+* [Author](#author)
+
+## Installation
+
+This is a [Node.js](https://nodejs.org/en/) module available through the
+[npm registry](https://www.npmjs.com/). Installation is done using the
+[`npm install` command](https://docs.npmjs.com/getting-started/installing-npm-packages-locally):
+
+```sh
+$ npm install cors
+```
+
+## Usage
+
+### Simple Usage (Enable *All* CORS Requests)
+
+```javascript
+var express = require('express')
+var cors = require('cors')
+var app = express()
+
+app.use(cors())
+
+app.get('/products/:id', function (req, res, next) {
+  res.json({msg: 'This is CORS-enabled for all origins!'})
+})
+
+app.listen(80, function () {
+  console.log('CORS-enabled web server listening on port 80')
+})
+```
+
+### Enable CORS for a Single Route
+
+```javascript
+var express = require('express')
+var cors = require('cors')
+var app = express()
+
+app.get('/products/:id', cors(), function (req, res, next) {
+  res.json({msg: 'This is CORS-enabled for a Single Route'})
+})
+
+app.listen(80, function () {
+  console.log('CORS-enabled web server listening on port 80')
+})
+```
+
+### Configuring CORS
+
+```javascript
+var express = require('express')
+var cors = require('cors')
+var app = express()
+
+var corsOptions = {
+  origin: 'http://example.com',
+  optionsSuccessStatus: 200 // some legacy browsers (IE11, various SmartTVs) choke on 204
+}
+
+app.get('/products/:id', cors(corsOptions), function (req, res, next) {
+  res.json({msg: 'This is CORS-enabled for only example.com.'})
+})
+
+app.listen(80, function () {
+  console.log('CORS-enabled web server listening on port 80')
+})
+```
+
+### Configuring CORS w/ Dynamic Origin
+
+```javascript
+var express = require('express')
+var cors = require('cors')
+var app = express()
+
+var whitelist = ['http://example1.com', 'http://example2.com']
+var corsOptions = {
+  origin: function (origin, callback) {
+    if (whitelist.indexOf(origin) !== -1) {
+      callback(null, true)
+    } else {
+      callback(new Error('Not allowed by CORS'))
+    }
+  }
+}
+
+app.get('/products/:id', cors(corsOptions), function (req, res, next) {
+  res.json({msg: 'This is CORS-enabled for a whitelisted domain.'})
+})
+
+app.listen(80, function () {
+  console.log('CORS-enabled web server listening on port 80')
+})
+```
+
+If you do not want to block REST tools or server-to-server requests,
+add a `!origin` check in the origin function like so:
+
+```javascript
+var corsOptions = {
+  origin: function (origin, callback) {
+    if (whitelist.indexOf(origin) !== -1 || !origin) {
+      callback(null, true)
+    } else {
+      callback(new Error('Not allowed by CORS'))
+    }
+  }
+}
+```
+
+### Enabling CORS Pre-Flight
+
+Certain CORS requests are considered 'complex' and require an initial
+`OPTIONS` request (called the "pre-flight request"). An example of a
+'complex' CORS request is one that uses an HTTP verb other than
+GET/HEAD/POST (such as DELETE) or that uses custom headers. To enable
+pre-flighting, you must add a new OPTIONS handler for the route you want
+to support:
+
+```javascript
+var express = require('express')
+var cors = require('cors')
+var app = express()
+
+app.options('/products/:id', cors()) // enable pre-flight request for DELETE request
+app.del('/products/:id', cors(), function (req, res, next) {
+  res.json({msg: 'This is CORS-enabled for all origins!'})
+})
+
+app.listen(80, function () {
+  console.log('CORS-enabled web server listening on port 80')
+})
+```
+
+You can also enable pre-flight across-the-board like so:
+
+```javascript
+app.options('*', cors()) // include before other routes
+```
+
+### Configuring CORS Asynchronously
+
+```javascript
+var express = require('express')
+var cors = require('cors')
+var app = express()
+
+var whitelist = ['http://example1.com', 'http://example2.com']
+var corsOptionsDelegate = function (req, callback) {
+  var corsOptions;
+  if (whitelist.indexOf(req.header('Origin')) !== -1) {
+    corsOptions = { origin: true } // reflect (enable) the requested origin in the CORS response
+  } else {
+    corsOptions = { origin: false } // disable CORS for this request
+  }
+  callback(null, corsOptions) // callback expects two parameters: error and options
+}
+
+app.get('/products/:id', cors(corsOptionsDelegate), function (req, res, next) {
+  res.json({msg: 'This is CORS-enabled for a whitelisted domain.'})
+})
+
+app.listen(80, function () {
+  console.log('CORS-enabled web server listening on port 80')
+})
+```
+
+## Configuration Options
+
+* `origin`: Configures the **Access-Control-Allow-Origin** CORS header. Possible values:
+  - `Boolean` - set `origin` to `true` to reflect the [request origin](http://tools.ietf.org/html/draft-abarth-origin-09), as defined by `req.header('Origin')`, or set it to `false` to disable CORS.
+  - `String` - set `origin` to a specific origin. For example if you set it to `"http://example.com"` only requests from "http://example.com" will be allowed.
+  - `RegExp` - set `origin` to a regular expression pattern which will be used to test the request origin. If it's a match, the request origin will be reflected. For example the pattern `/example\.com$/` will reflect any request that is coming from an origin ending with "example.com".
+  - `Array` - set `origin` to an array of valid origins. Each origin can be a `String` or a `RegExp`. For example `["http://example1.com", /\.example2\.com$/]` will accept any request from "http://example1.com" or from a subdomain of "example2.com".
+  - `Function` - set `origin` to a function implementing some custom logic. The function takes the request origin as the first parameter and a callback (which expects the signature `err [object], allow [bool]`) as the second.
+* `methods`: Configures the **Access-Control-Allow-Methods** CORS header. Expects a comma-delimited string (ex: 'GET,PUT,POST') or an array (ex: `['GET', 'PUT', 'POST']`).
+* `allowedHeaders`: Configures the **Access-Control-Allow-Headers** CORS header. Expects a comma-delimited string (ex: 'Content-Type,Authorization') or an array (ex: `['Content-Type', 'Authorization']`). If not specified, defaults to reflecting the headers specified in the request's **Access-Control-Request-Headers** header.
+* `exposedHeaders`: Configures the **Access-Control-Expose-Headers** CORS header. Expects a comma-delimited string (ex: 'Content-Range,X-Content-Range') or an array (ex: `['Content-Range', 'X-Content-Range']`). If not specified, no custom headers are exposed.
+* `credentials`: Configures the **Access-Control-Allow-Credentials** CORS header. Set to `true` to pass the header, otherwise it is omitted.
+* `maxAge`: Configures the **Access-Control-Max-Age** CORS header. Set to an integer to pass the header, otherwise it is omitted.
+* `preflightContinue`: Pass the CORS preflight response to the next handler.
+* `optionsSuccessStatus`: Provides a status code to use for successful `OPTIONS` requests, since some legacy browsers (IE11, various SmartTVs) choke on `204`.
+
+The default configuration is the equivalent of:
+
+```json
+{
+  "origin": "*",
+  "methods": "GET,HEAD,PUT,PATCH,POST,DELETE",
+  "preflightContinue": false,
+  "optionsSuccessStatus": 204
+}
+```
+
+For details on the effect of each CORS header, read [this](http://www.html5rocks.com/en/tutorials/cors/) article on HTML5 Rocks.
+
+## Demo
+
+A demo that illustrates CORS working (and not working) using jQuery is available here: [http://node-cors-client.herokuapp.com/](http://node-cors-client.herokuapp.com/)
+
+Code for that demo can be found here:
+
+* Client: [https://github.com/TroyGoode/node-cors-client](https://github.com/TroyGoode/node-cors-client)
+* Server: [https://github.com/TroyGoode/node-cors-server](https://github.com/TroyGoode/node-cors-server)
+
+## License
+
+[MIT License](http://www.opensource.org/licenses/mit-license.php)
+
+## Author
+
+[Troy Goode](https://github.com/TroyGoode) ([troygoode@gmail.com](mailto:troygoode@gmail.com))
+
+[coveralls-image]: https://img.shields.io/coveralls/expressjs/cors/master.svg
+[coveralls-url]: https://coveralls.io/r/expressjs/cors?branch=master
+[downloads-image]: https://img.shields.io/npm/dm/cors.svg
+[downloads-url]: https://npmjs.org/package/cors
+[npm-image]: https://img.shields.io/npm/v/cors.svg
+[npm-url]: https://npmjs.org/package/cors
+[travis-image]: https://img.shields.io/travis/expressjs/cors/master.svg
+[travis-url]: https://travis-ci.org/expressjs/cors

--- a/backend/node_modules/cors/lib/index.js
+++ b/backend/node_modules/cors/lib/index.js
@@ -1,0 +1,238 @@
+(function () {
+
+  'use strict';
+
+  var assign = require('object-assign');
+  var vary = require('vary');
+
+  var defaults = {
+    origin: '*',
+    methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
+    preflightContinue: false,
+    optionsSuccessStatus: 204
+  };
+
+  function isString(s) {
+    return typeof s === 'string' || s instanceof String;
+  }
+
+  function isOriginAllowed(origin, allowedOrigin) {
+    if (Array.isArray(allowedOrigin)) {
+      for (var i = 0; i < allowedOrigin.length; ++i) {
+        if (isOriginAllowed(origin, allowedOrigin[i])) {
+          return true;
+        }
+      }
+      return false;
+    } else if (isString(allowedOrigin)) {
+      return origin === allowedOrigin;
+    } else if (allowedOrigin instanceof RegExp) {
+      return allowedOrigin.test(origin);
+    } else {
+      return !!allowedOrigin;
+    }
+  }
+
+  function configureOrigin(options, req) {
+    var requestOrigin = req.headers.origin,
+      headers = [],
+      isAllowed;
+
+    if (!options.origin || options.origin === '*') {
+      // allow any origin
+      headers.push([{
+        key: 'Access-Control-Allow-Origin',
+        value: '*'
+      }]);
+    } else if (isString(options.origin)) {
+      // fixed origin
+      headers.push([{
+        key: 'Access-Control-Allow-Origin',
+        value: options.origin
+      }]);
+      headers.push([{
+        key: 'Vary',
+        value: 'Origin'
+      }]);
+    } else {
+      isAllowed = isOriginAllowed(requestOrigin, options.origin);
+      // reflect origin
+      headers.push([{
+        key: 'Access-Control-Allow-Origin',
+        value: isAllowed ? requestOrigin : false
+      }]);
+      headers.push([{
+        key: 'Vary',
+        value: 'Origin'
+      }]);
+    }
+
+    return headers;
+  }
+
+  function configureMethods(options) {
+    var methods = options.methods;
+    if (methods.join) {
+      methods = options.methods.join(','); // .methods is an array, so turn it into a string
+    }
+    return {
+      key: 'Access-Control-Allow-Methods',
+      value: methods
+    };
+  }
+
+  function configureCredentials(options) {
+    if (options.credentials === true) {
+      return {
+        key: 'Access-Control-Allow-Credentials',
+        value: 'true'
+      };
+    }
+    return null;
+  }
+
+  function configureAllowedHeaders(options, req) {
+    var allowedHeaders = options.allowedHeaders || options.headers;
+    var headers = [];
+
+    if (!allowedHeaders) {
+      allowedHeaders = req.headers['access-control-request-headers']; // .headers wasn't specified, so reflect the request headers
+      headers.push([{
+        key: 'Vary',
+        value: 'Access-Control-Request-Headers'
+      }]);
+    } else if (allowedHeaders.join) {
+      allowedHeaders = allowedHeaders.join(','); // .headers is an array, so turn it into a string
+    }
+    if (allowedHeaders && allowedHeaders.length) {
+      headers.push([{
+        key: 'Access-Control-Allow-Headers',
+        value: allowedHeaders
+      }]);
+    }
+
+    return headers;
+  }
+
+  function configureExposedHeaders(options) {
+    var headers = options.exposedHeaders;
+    if (!headers) {
+      return null;
+    } else if (headers.join) {
+      headers = headers.join(','); // .headers is an array, so turn it into a string
+    }
+    if (headers && headers.length) {
+      return {
+        key: 'Access-Control-Expose-Headers',
+        value: headers
+      };
+    }
+    return null;
+  }
+
+  function configureMaxAge(options) {
+    var maxAge = (typeof options.maxAge === 'number' || options.maxAge) && options.maxAge.toString()
+    if (maxAge && maxAge.length) {
+      return {
+        key: 'Access-Control-Max-Age',
+        value: maxAge
+      };
+    }
+    return null;
+  }
+
+  function applyHeaders(headers, res) {
+    for (var i = 0, n = headers.length; i < n; i++) {
+      var header = headers[i];
+      if (header) {
+        if (Array.isArray(header)) {
+          applyHeaders(header, res);
+        } else if (header.key === 'Vary' && header.value) {
+          vary(res, header.value);
+        } else if (header.value) {
+          res.setHeader(header.key, header.value);
+        }
+      }
+    }
+  }
+
+  function cors(options, req, res, next) {
+    var headers = [],
+      method = req.method && req.method.toUpperCase && req.method.toUpperCase();
+
+    if (method === 'OPTIONS') {
+      // preflight
+      headers.push(configureOrigin(options, req));
+      headers.push(configureCredentials(options, req));
+      headers.push(configureMethods(options, req));
+      headers.push(configureAllowedHeaders(options, req));
+      headers.push(configureMaxAge(options, req));
+      headers.push(configureExposedHeaders(options, req));
+      applyHeaders(headers, res);
+
+      if (options.preflightContinue) {
+        next();
+      } else {
+        // Safari (and potentially other browsers) need content-length 0,
+        //   for 204 or they just hang waiting for a body
+        res.statusCode = options.optionsSuccessStatus;
+        res.setHeader('Content-Length', '0');
+        res.end();
+      }
+    } else {
+      // actual response
+      headers.push(configureOrigin(options, req));
+      headers.push(configureCredentials(options, req));
+      headers.push(configureExposedHeaders(options, req));
+      applyHeaders(headers, res);
+      next();
+    }
+  }
+
+  function middlewareWrapper(o) {
+    // if options are static (either via defaults or custom options passed in), wrap in a function
+    var optionsCallback = null;
+    if (typeof o === 'function') {
+      optionsCallback = o;
+    } else {
+      optionsCallback = function (req, cb) {
+        cb(null, o);
+      };
+    }
+
+    return function corsMiddleware(req, res, next) {
+      optionsCallback(req, function (err, options) {
+        if (err) {
+          next(err);
+        } else {
+          var corsOptions = assign({}, defaults, options);
+          var originCallback = null;
+          if (corsOptions.origin && typeof corsOptions.origin === 'function') {
+            originCallback = corsOptions.origin;
+          } else if (corsOptions.origin) {
+            originCallback = function (origin, cb) {
+              cb(null, corsOptions.origin);
+            };
+          }
+
+          if (originCallback) {
+            originCallback(req.headers.origin, function (err2, origin) {
+              if (err2 || !origin) {
+                next(err2);
+              } else {
+                corsOptions.origin = origin;
+                cors(corsOptions, req, res, next);
+              }
+            });
+          } else {
+            next();
+          }
+        }
+      });
+    };
+  }
+
+  // can pass either an options hash, an options delegate, or nothing
+  module.exports = middlewareWrapper;
+
+}());

--- a/backend/node_modules/cors/package.json
+++ b/backend/node_modules/cors/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "cors",
+  "description": "Node.js CORS middleware",
+  "version": "2.8.5",
+  "author": "Troy Goode <troygoode@gmail.com> (https://github.com/troygoode/)",
+  "license": "MIT",
+  "keywords": [
+    "cors",
+    "express",
+    "connect",
+    "middleware"
+  ],
+  "repository": "expressjs/cors",
+  "main": "./lib/index.js",
+  "dependencies": {
+    "object-assign": "^4",
+    "vary": "^1"
+  },
+  "devDependencies": {
+    "after": "0.8.2",
+    "eslint": "2.13.1",
+    "express": "4.16.3",
+    "mocha": "5.2.0",
+    "nyc": "13.1.0",
+    "supertest": "3.3.0"
+  },
+  "files": [
+    "lib/index.js",
+    "CONTRIBUTING.md",
+    "HISTORY.md",
+    "LICENSE",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">= 0.10"
+  },
+  "scripts": {
+    "test": "npm run lint && nyc --reporter=html --reporter=text mocha --require test/support/env",
+    "lint": "eslint lib test"
+  }
+}

--- a/backend/node_modules/helmet/CHANGELOG.md
+++ b/backend/node_modules/helmet/CHANGELOG.md
@@ -1,0 +1,891 @@
+# Changelog
+
+## 6.0.1 - 2022-11-29
+
+### Fixed
+
+- `crossOriginEmbedderPolicy` did not accept options at the top level. See [#390](https://github.com/helmetjs/helmet/issues/390)
+
+## 6.0.0 - 2022-08-26
+
+### Changed
+
+- **Breaking:** `helmet.contentSecurityPolicy` no longer sets `block-all-mixed-content` directive by default
+- **Breaking:** `helmet.expectCt` is no longer set by default. It can, however, be explicitly enabled. It will be removed in Helmet 7. See [#310](https://github.com/helmetjs/helmet/issues/310)
+- **Breaking:** Increase TypeScript strictness around some arguments. Only affects TypeScript users, and may not require any code changes. See [#369](https://github.com/helmetjs/helmet/issues/369)
+- `helmet.frameguard` no longer offers a specific error when trying to use `ALLOW-FROM`; it just says that it is unsupported. Only the error message has changed
+
+### Removed
+
+- **Breaking:** Dropped support for Node 12 and 13. Node 14+ is now required
+
+## 5.1.1 - 2022-07-23
+
+### Changed
+
+- Fix TypeScript bug with some TypeScript configurations. See [#375](https://github.com/helmetjs/helmet/pull/375) and [#359](https://github.com/helmetjs/helmet/issues/359)
+
+## 5.1.0 - 2022-05-17
+
+### Added
+
+- `Cross-Origin-Embedder-Policy`: support `credentialless` policy. See [#365](https://github.com/helmetjs/helmet/pull/365)
+- Documented how to set both `Content-Security-Policy` and `Content-Security-Policy-Report-Only`
+
+### Changed
+
+- Cleaned up some documentation around `Origin-Agent-Cluster`
+
+## 5.0.2 - 2022-01-22
+
+### Changed
+
+- Improve imports for CommonJS and ECMAScript modules. See [#345](https://github.com/helmetjs/helmet/pull/345)
+- Fixed some documentation
+
+## 5.0.1 - 2022-01-03
+
+### Changed
+
+- Fixed some documentation
+
+### Removed
+
+- Removed some unused internal code
+
+## 5.0.0 - 2022-01-02
+
+### Added
+
+- ECMAScript module imports (i.e., `import helmet from "helmet"` and `import { frameguard } from "helmet"`). See [#320](https://github.com/helmetjs/helmet/issues/320)
+
+### Changed
+
+- **Breaking:** `helmet.contentSecurityPolicy`: `useDefaults` option now defaults to `true`
+- **Breaking:** `helmet.contentSecurityPolicy`: `form-action` directive is now set to `'self'` by default
+- **Breaking:** `helmet.crossOriginEmbedderPolicy` is enabled by default
+- **Breaking:** `helmet.crossOriginOpenerPolicy` is enabled by default
+- **Breaking:** `helmet.crossOriginResourcePolicy` is enabled by default
+- **Breaking:** `helmet.originAgentCluster` is enabled by default
+- `helmet.frameguard`: add TypeScript editor autocomplete. See [#322](https://github.com/helmetjs/helmet/pull/322)
+- Top-level `helmet()` function is slightly faster
+
+### Removed
+
+- **Breaking:** Drop support for Node 10 and 11. Node 12+ is now required
+
+## 4.6.0 - 2021-05-01
+
+### Added
+
+- `helmet.contentSecurityPolicy`: the `useDefaults` option, defaulting to `false`, lets you selectively override defaults more easily
+- Explicitly define TypeScript types in `package.json`. See [#303](https://github.com/helmetjs/helmet/pull/303)
+
+## 4.5.0 - 2021-04-17
+
+### Added
+
+- `helmet.crossOriginEmbedderPolicy`: a new middleware for the `Cross-Origin-Embedder-Policy` header, disabled by default
+- `helmet.crossOriginOpenerPolicy`: a new middleware for the `Cross-Origin-Opener-Policy` header, disabled by default
+- `helmet.crossOriginResourcePolicy`: a new middleware for the `Cross-Origin-Resource-Policy` header, disabled by default
+
+### Changed
+
+- `true` enables a middleware with default options. Previously, this would fail with an error if the middleware was already enabled by default.
+- Log a warning when passing options to `originAgentCluster` at the top level
+
+### Fixed
+
+- Incorrect documentation
+
+## 4.4.1 - 2021-01-18
+
+### Changed
+
+- Shrink the published package by about 2.5 kB
+
+## 4.4.0 - 2021-01-17
+
+### Added
+
+- `helmet.originAgentCluster`: a new middleware for the `Origin-Agent-Cluster` header, disabled by default
+
+## 4.3.1 - 2020-12-27
+
+### Fixed
+
+- `helmet.contentSecurityPolicy`: broken TypeScript types. See [#283](https://github.com/helmetjs/helmet/issues/283)
+
+## 4.3.0 - 2020-12-27
+
+### Added
+
+- `helmet.contentSecurityPolicy`: setting the `default-src` to `helmet.contentSecurityPolicy.dangerouslyDisableDefaultSrc` disables it
+
+### Changed
+
+- `helmet.frameguard`: slightly improved error messages for non-strings
+
+## 4.2.0 - 2020-11-01
+
+### Added
+
+- `helmet.contentSecurityPolicy`: get the default directives with `contentSecurityPolicy.getDefaultDirectives()`
+
+### Changed
+
+- `helmet()` now supports objects that don't have `Object.prototype` in their chain, such as `Object.create(null)`, as options
+- `helmet.expectCt`: `max-age` is now first. See [#264](https://github.com/helmetjs/helmet/pull/264)
+
+## 4.1.1 - 2020-09-10
+
+### Changed
+
+- Fixed a few errors in the README
+
+## 4.1.0 - 2020-08-15
+
+### Added
+
+- `helmet.contentSecurityPolicy`:
+  - Directive values can now include functions, as they could in Helmet 3. See [#243](https://github.com/helmetjs/helmet/issues/243)
+
+### Changed
+
+- Helmet should now play more nicely with TypeScript
+
+### Removed
+
+- The `HelmetOptions` interface is no longer exported. This only affects TypeScript users. If you need the functionality back, see [this comment](https://github.com/helmetjs/helmet/issues/235#issuecomment-674016883)
+
+## 4.0.0 - 2020-08-02
+
+See the [Helmet 4 upgrade guide](https://github.com/helmetjs/helmet/wiki/Helmet-4-upgrade-guide) for help upgrading from Helmet 3.
+
+### Added
+
+- `helmet.contentSecurityPolicy`:
+  - If no `default-src` directive is supplied, an error is thrown
+  - Directive lists can be any iterable, not just arrays
+
+### Changed
+
+- This package no longer has dependencies. This should have no effect on end users, other than speeding up installation time.
+- `helmet.contentSecurityPolicy`:
+  - There is now a default set of directives if none are supplied
+  - Duplicate keys now throw an error. See [helmetjs/csp#73](https://github.com/helmetjs/csp/issues/73)
+  - This middleware is more lenient, allowing more directive names or values
+- `helmet.xssFilter` now disables the buggy XSS filter by default. See [#230](https://github.com/helmetjs/helmet/issues/230)
+
+### Removed
+
+- Dropped support for old Node versions. Node 10+ is now required
+- `helmet.featurePolicy`. If you still need it, use the `feature-policy` package on npm.
+- `helmet.hpkp`. If you still need it, use the `hpkp` package on npm.
+- `helmet.noCache`. If you still need it, use the `nocache` package on npm.
+- `helmet.contentSecurityPolicy`:
+  - Removed browser sniffing (including the `browserSniff` and `disableAndroid` parameters). See [helmetjs/csp#97](https://github.com/helmetjs/csp/issues/97)
+  - Removed conditional support. This includes directive functions and support for a function as the `reportOnly`. [Read this if you need help.](https://github.com/helmetjs/helmet/wiki/Conditionally-using-middleware)
+  - Removed a lot of checks—you should be checking your CSP with a different tool
+  - Removed support for legacy headers (and therefore the `setAllHeaders` parameter). [Read this if you need help.](https://github.com/helmetjs/helmet/wiki/Setting-legacy-Content-Security-Policy-headers-in-Helmet-4)
+  - Removed the `loose` option
+  - Removed support for functions as directive values. You must supply an iterable of strings
+- `helmet.frameguard`:
+  - Dropped support for the `ALLOW-FROM` action. [Read more here.](https://github.com/helmetjs/helmet/wiki/How-to-use-X%E2%80%93Frame%E2%80%93Options's-%60ALLOW%E2%80%93FROM%60-directive)
+- `helmet.hidePoweredBy` no longer accepts arguments. See [this article](https://github.com/helmetjs/helmet/wiki/How-to-set-a-custom-X%E2%80%93Powered%E2%80%93By-header) to see how to replicate the removed behavior. See [#224](https://github.com/helmetjs/helmet/issues/224).
+- `helmet.hsts`:
+  - Dropped support for `includeSubdomains` with a lowercase D. See [#231](https://github.com/helmetjs/helmet/issues/231)
+  - Dropped support for `setIf`. [Read this if you need help.](https://github.com/helmetjs/helmet/wiki/Conditionally-using-middleware) See [#232](https://github.com/helmetjs/helmet/issues/232)
+- `helmet.xssFilter` no longer accepts options. Read ["How to disable blocking with X-XSS-Protection"](https://github.com/helmetjs/helmet/wiki/How-to-disable-blocking-with-X%E2%80%93XSS%E2%80%93Protection) and ["How to enable the `report` directive with X-XSS-Protection"](https://github.com/helmetjs/helmet/wiki/How-to-enable-the-%60report%60-directive-with-X%E2%80%93XSS%E2%80%93Protection) if you need the legacy behavior.
+
+## 3.23.3 - 2020-06-26
+
+### Changed
+
+- `helmet.expectCt` is no longer a separate package. This should have no effect on end users.
+- `helmet.frameguard` is no longer a separate package. This should have no effect on end users.
+
+## 3.23.2 - 2020-06-23
+
+### Changed
+
+- `helmet.dnsPrefetchControl` is no longer a separate package. This should have no effect on end users.
+
+## 3.23.1 - 2020-06-16
+
+### Changed
+
+- `helmet.ieNoOpen` is no longer a separate package. This should have no effect on end users.
+
+## 3.23.0 - 2020-06-12
+
+### Deprecated
+
+- `helmet.featurePolicy` is deprecated. Use the `feature-policy` module instead.
+
+## 3.22.1 - 2020-06-10
+
+### Changed
+
+- Rewrote internals in TypeScript. This should have no effect on end users.
+
+## 3.22.0 - 2020-03-24
+
+### Changed
+
+- Updated `helmet-csp` to v2.10.0
+  - Add support for the `allow-downloads` sandbox directive. See [helmet-csp#103](https://github.com/helmetjs/csp/pull/103)
+
+### Deprecated
+
+- `helmet.noCache` is deprecated. Use the `nocache` module instead. See [#215](https://github.com/helmetjs/helmet/issues/215)
+
+## 3.21.3 - 2020-02-24
+
+### Changed
+
+- Updated `helmet-csp` to v2.9.5
+  - Updated `bowser` subdependency from 2.7.0 to 2.9.0
+  - Fixed an issue some people were having when importing the `bowser` subdependency. See [helmet-csp#96](https://github.com/helmetjs/csp/issues/96) and [#101](https://github.com/helmetjs/csp/pull/101)
+
+## 3.21.2 - 2019-10-21
+
+### Changed
+
+- Updated `helmet-csp` to v2.9.4
+  - Updated `bowser` subdependency from 2.6.1 to 2.7.0. See [helmet-csp#94](https://github.com/helmetjs/csp/pull/94)
+
+## 3.21.1 - 2019-09-20
+
+### Fixed
+
+- Updated `helmet-csp` to v2.9.2
+  - Fixed a bug where a request from Firefox 4 could delete `default-src` from future responses
+  - Fixed tablet PC detection by updating `bowser` subdependency to latest version
+
+## 3.21.0 - 2019-09-04
+
+### Added
+
+- Updated `x-xss-protection` to v1.3.0
+  - Added `mode: null` to disable `mode=block`
+
+### Changed
+
+- Updated `helmet-csp` to v2.9.1
+  - Updated `bowser` subdependency from 2.5.3 to 2.5.4. See [helmet-csp#88](https://github.com/helmetjs/csp/pull/88)
+
+## 3.20.1 - 2019-08-28
+
+### Changed
+
+- Updated `helmet-csp` to v2.9.0
+
+## 3.20.0 - 2019-07-24
+
+### Changed
+
+- Updated `helmet-csp` to v2.8.0
+
+## 3.19.0 - 2019-07-17
+
+### Changed
+
+- Updated `dns-prefetch-control` to v0.2.0
+- Updated `dont-sniff-mimetype` to v1.1.0
+- Updated `helmet-crossdomain` to v0.4.0
+- Updated `hide-powered-by` to v1.1.0
+- Updated `x-xss-protection` to v1.2.0
+
+## 3.18.0 - 2019-05-05
+
+### Added
+
+- `featurePolicy` has 19 new features: `ambientLightSensor`, `documentDomain`, `documentWrite`, `encryptedMedia`, `fontDisplayLateSwap`, `layoutAnimations`, `legacyImageFormats`, `loadingFrameDefaultEager`, `oversizedImages`, `pictureInPicture`, `serial`, `syncScript`, `unoptimizedImages`, `unoptimizedLosslessImages`, `unoptimizedLossyImages`, `unsizedMedia`, `verticalScroll`, `wakeLock`, and `xr`
+
+### Changed
+
+- Updated `expect-ct` to v0.2.0
+- Updated `feature-policy` to v0.3.0
+- Updated `frameguard` to v3.1.0
+- Updated `nocache` to v2.1.0
+
+## 3.17.0 - 2019-05-03
+
+### Added
+
+- `referrerPolicy` now supports multiple values
+
+### Changed
+
+- Updated `referrerPolicy` to v1.2.0
+
+## 3.16.0 - 2019-03-10
+
+### Added
+
+- Add email to `bugs` field in `package.json`
+
+### Changed
+
+- Updated `hsts` to v2.2.0
+- Updated `ienoopen` to v1.1.0
+- Changelog is now in the [Keep A Changelog](https://keepachangelog.com/) format
+- Dropped support for Node <4. See [the commit](https://github.com/helmetjs/helmet/commit/a49cec3ca58cce484d2d05e1f908549caa92ed03) for more information
+- Updated Adam Baldwin's contact information
+
+### Deprecated
+
+- `helmet.hsts`'s `setIf` option has been deprecated and will be removed in `hsts@3`. See [helmetjs/hsts#22](https://github.com/helmetjs/hsts/issues/22) for more
+
+* The `includeSubdomains` option (with a lowercase `d`) has been deprecated and will be removed in `hsts@3`. Use the uppercase-D `includeSubDomains` option instead. See [helmetjs/hsts#21](https://github.com/helmetjs/hsts/issues/21) for more
+
+## 3.15.1 - 2019-02-10
+
+### Deprecated
+
+- The `hpkp` middleware has been deprecated. If you still need to use this module, install the standalone `hpkp` module from npm. See [#180](https://github.com/helmetjs/helmet/issues/180) for more.
+
+## 3.15.0 - 2018-11-07
+
+### Added
+
+- `helmet.featurePolicy` now supports four new features
+
+## 3.14.0 - 2018-10-09
+
+### Added
+
+- `helmet.featurePolicy` middleware
+
+## 3.13.0 - 2018-07-22
+
+### Added
+
+- `helmet.permittedCrossDomainPolicies` middleware
+
+## 3.12.2 - 2018-07-20
+
+### Fixed
+
+- Removed `lodash.reduce` dependency from `csp`
+
+## 3.12.1 - 2018-05-16
+
+### Fixed
+
+- `expectCt` should use comma instead of semicolon as delimiter
+
+## 3.12.0 - 2018-03-02
+
+### Added
+
+- `xssFilter` now supports `reportUri` option
+
+## 3.11.0 - 2018-02-09
+
+### Added
+
+- Main Helmet middleware is now named to help with debugging
+
+## 3.10.0 - 2018-01-23
+
+### Added
+
+- `csp` now supports `prefix-src` directive
+
+### Fixed
+
+- `csp` no longer loads JSON files internally, helping some module bundlers
+- `false` should be able to disable a CSP directive
+
+## 3.9.0 - 2017-10-13
+
+### Added
+
+- `csp` now supports `strict-dynamic` value
+- `csp` now supports `require-sri-for` directive
+
+### Changed
+
+- Removed `connect` dependency
+
+## 3.8.2 - 2017-09-27
+
+### Changed
+
+- Updated `connect` dependency to latest
+
+## 3.8.1 - 2017-07-28
+
+### Fixed
+
+- `csp` does not automatically set `report-to` when setting `report-uri`
+
+## 3.8.0 - 2017-07-21
+
+### Changed
+
+- `hsts` no longer cares whether it's HTTPS and always sets the header
+
+## 3.7.0 - 2017-07-21
+
+### Added
+
+- `csp` now supports `report-to` directive
+
+### Changed
+
+- Throw an error when used incorrectly
+- Add a few documentation files to `npmignore`
+
+## 3.6.1 - 2017-05-21
+
+### Changed
+
+- Bump `connect` version
+
+## 3.6.0 - 2017-05-04
+
+### Added
+
+- `expectCt` middleware for setting the `Expect-CT` header
+
+## 3.5.0 - 2017-03-06
+
+### Added
+
+- `csp` now supports the `worker-src` directive
+
+## 3.4.1 - 2017-02-24
+
+### Changed
+
+- Bump `connect` version
+
+## 3.4.0 - 2017-01-13
+
+### Added
+
+- `csp` now supports more `sandbox` directives
+
+## 3.3.0 - 2016-12-31
+
+### Added
+
+- `referrerPolicy` allows `strict-origin` and `strict-origin-when-cross-origin` directives
+
+### Changed
+
+- Bump `connect` version
+
+## 3.2.0 - 2016-12-22
+
+### Added
+
+- `csp` now allows `manifest-src` directive
+
+## 3.1.0 - 2016-11-03
+
+### Added
+
+- `csp` now allows `frame-src` directive
+
+## 3.0.0 - 2016-10-28
+
+### Changed
+
+- `csp` will check your directives for common mistakes and throw errors if it finds them. This can be disabled with `loose: true`.
+- Empty arrays are no longer allowed in `csp`. For source lists (like `script-src` or `object-src`), use the standard `scriptSrc: ["'none'"]`. The `sandbox` directive can be `sandbox: true` to block everything.
+- `false` can disable a CSP directive. For example, `scriptSrc: false` is the same as not specifying it.
+- In CSP, `reportOnly: true` no longer requires a `report-uri` to be set.
+- `hsts`'s `maxAge` now defaults to 180 days (instead of 1 day)
+- `hsts`'s `maxAge` parameter is seconds, not milliseconds
+- `hsts` includes subdomains by default
+- `domain` parameter in `frameguard` cannot be empty
+
+### Removed
+
+- `noEtag` option no longer present in `noCache`
+- iOS Chrome `connect-src` workaround in CSP module
+
+## 2.3.0 - 2016-09-30
+
+### Added
+
+- `hpkp` middleware now supports the `includeSubDomains` property with a capital D
+
+### Fixed
+
+- `hpkp` was setting `includeSubdomains` instead of `includeSubDomains`
+
+## 2.2.0 - 2016-09-16
+
+### Added
+
+- `referrerPolicy` middleware
+
+## 2.1.3 - 2016-09-07
+
+### Changed
+
+- Top-level aliases (like `helmet.xssFilter`) are no longer dynamically required
+
+## 2.1.2 - 2016-07-27
+
+### Deprecated
+
+- `nocache`'s `noEtag` option is now deprecated
+
+### Fixed
+
+- `csp` now better handles Firefox on mobile
+
+## 2.1.1 - 2016-06-10
+
+### Changed
+
+- Remove several dependencies from `helmet-csp`
+
+### Fixed
+
+- `frameguard` had a documentation error about its default value
+- `frameguard` docs in main Helmet readme said `frameguard`, not `helmet.frameguard`
+
+## 2.1.0 - 2016-05-18
+
+### Added
+
+- `csp` lets you dynamically set `reportOnly`
+
+## 2.0.0 - 2016-04-29
+
+### Added
+
+- Pass configuration to enable/disable default middlewares
+
+### Changed
+
+- `dnsPrefetchControl` middleware is now enabled by default
+
+### Removed
+
+- No more module aliases. There is now just one way to include each middleware
+- `frameguard` can no longer be initialized with strings; you must use an object
+
+### Fixed
+
+- Make `hpkp` lowercase in documentation
+- Update `hpkp` spec URL in readmes
+- Update `frameguard` header name in readme
+
+## 1.3.0 - 2016-03-01
+
+### Added
+
+- `hpkp` has a `setIf` option to conditionally set the header
+
+## 1.2.0 - 2016-02-29
+
+### Added
+
+- `csp` now has a `browserSniff` option to disable all user-agent sniffing
+
+### Changed
+
+- `frameguard` can now be initialized with options
+- Add `npmignore` file to speed up installs slightly
+
+## 1.1.0 - 2016-01-12
+
+### Added
+
+- Code of conduct
+- `dnsPrefetchControl` middleware
+
+### Fixed
+
+- `csp` readme had syntax errors
+
+## 1.0.2 - 2016-01-08
+
+### Fixed
+
+- `csp` wouldn't recognize `IE Mobile` browsers
+- `csp` had some errors in its readme
+- Main readme had a syntax error
+
+## 1.0.1 - 2015-12-19
+
+### Fixed
+
+- `csp` with no User Agent would cause errors
+
+## 1.0.0 - 2015-12-18
+
+### Added
+
+- `csp` module supports dynamically-generated values
+
+### Changed
+
+- `csp` directives are now under the `directives` key
+- `hpkp`'s `Report-Only` header is now opt-in, not opt-out
+- Tweak readmes of every sub-repo
+
+### Removed
+
+- `crossdomain` middleware
+- `csp` no longer throws errors when some directives aren't quoted (`'self'`, for example)
+- `maxage` option in the `hpkp` middleware
+- `safari5` option from `csp` module
+
+### Fixed
+
+- Old Firefox Content-Security-Policy behavior for `unsafe-inline` and `unsafe-eval`
+- Dynamic `csp` policies is no longer recursive
+
+## 0.15.0 - 2015-11-26
+
+### Changed
+
+- `hpkp` allows a `report-uri` without the `Report-Only` header
+
+## 0.14.0 - 2015-11-01
+
+### Added
+
+- `nocache` now sends the `Surrogate-Control` header
+
+### Changed
+
+- `nocache` no longer contains the `private` directive in the `Cache-Control` header
+
+## 0.13.0 - 2015-10-23
+
+### Added
+
+- `xssFilter` now has a function name
+- Added new CSP docs to readme
+
+### Changed
+
+- HSTS option renamed from `includeSubdomains` to `includeSubDomains`
+
+## 0.11.0 - 2015-09-18
+
+### Added
+
+- `csp` now supports Microsoft Edge
+- CSP Level 2 support
+
+### Changed
+
+- Updated `connect` to 3.4.0
+- Updated `depd` to 1.1.0
+
+### Fixed
+
+- Added `license` key to `csp`'s `package.json`
+- Empty `csp` directives now support every directive, not just `sandbox`
+
+## 0.10.0 - 2015-07-08
+
+### Added
+
+- Add "Handling CSP violations" to `csp` readme
+- Add license to `package.json`
+
+### Changed
+
+- `hpkp` had a link to the wrong place in its readme
+- `hpkp` requires 2 or more pins
+
+### Fixed
+
+- `hpkp` might have miscalculated `maxAge` slightly wrong
+
+## 0.9.0 - 2015-04-24
+
+### Changed
+
+- `nocache` adds `private` to its `Cache-Control` directive
+- Added a description to `package.json`
+
+## 0.8.0 - 2015-04-21
+
+### Changed
+
+- Removed hefty Lodash dependency from HSTS and CSP
+- Updated string detection module in Frameguard
+- Changed readme slightly to better reflect project's focus
+
+### Deprecated
+
+- Deprecated `crossdomain` middleware
+
+### Removed
+
+- `crossdomain` is no longer a default middleware
+
+## 0.7.1 - 2015-03-23
+
+### Changed
+
+- Updated all outdated dependencies (insofar as possible)
+- HSTS now uses Lodash like all the rest of the libraries
+
+## 0.7.0 - 2015-03-05
+
+### Added
+
+- `hpkp` middleware
+
+### Changed
+
+- Travis CI should test 0.10 and 0.12
+- Minor code cleanup
+
+## 0.6.2 - 2015-03-01
+
+### Changed
+
+- Improved `xssFilter` performance
+- Updated Lodash versions
+
+## 0.6.1 - 2015-02-13
+
+### Added
+
+- "Other recommended modules" in README
+
+### Changed
+
+- Updated Lodash version
+
+### Fixed
+
+- `frameguard` middleware exported a function called `xframe`
+
+## 0.6.0 - 2015-01-21
+
+### Added
+
+- You can disable `csp` for Android
+
+### Fixed
+
+- `csp` on Chrome Mobile on Android and iOS
+
+## 0.5.4 - 2014-12-21
+
+### Changed
+
+- `nocache` should force revalidation
+
+## 0.5.3 - 2014-12-08
+
+### Changed
+
+- `platform` version in CSP and X-XSS-Protection
+
+### Fixed
+
+- Updated bad wording in frameguard docs
+
+## 0.5.2 - 2014-11-16
+
+### Changed
+
+- Updated Connect version
+
+### Fixed
+
+- Fixed minor `csp` bugfixes
+
+## 0.5.1 - 2014-11-09
+
+### Changed
+
+- Updated URLs in `package.json` for new URL
+
+### Fixed
+
+- CSP would set all headers forever after receiving an unknown user agent
+
+## 0.5.0 - 2014-10-28
+
+### Added
+
+- Most middlewares have some aliases now
+
+### Changed
+
+- `xframe` now called `frameguard` (though `xframe` still works)
+- `frameguard` chooses sameorigin by default
+- `frameguard` understands "SAME-ORIGIN" in addition to "SAMEORIGIN"
+- `nocache` removed from default middleware stack
+- Middleware split out into their own modules
+- Documentation
+- Updated supported Node version to at least 0.10.0
+- Bumped Connect version
+
+### Removed
+
+- Deprecation warnings
+
+### Fixed
+
+- Readme link was broken
+
+## 0.4.2 - 2014-10-16
+
+### Added
+
+- Support preload in HSTS header
+
+## 0.4.1 - 2014-08-24
+
+### Added
+
+- Use [helmet-crossdomain](https://github.com/helmetjs/crossdomain) to test the waters
+- 2 spaces instead of 4 throughout the code
+
+## 0.4.0 - 2014-07-17
+
+### Added
+
+- `nocache` now sets the Expires and Pragma headers
+- `nocache` now allows you to crush ETags
+
+### Changed
+
+- Improved the docs for nosniff
+- Reverted HSTS behavior of requiring a specified max-age
+
+### Fixed
+
+- Allow HSTS to have a max-age of 0
+
+## 0.3.2 - 2014-06-30
+
+### Added
+
+- All middleware functions are named
+- Throw error with non-positive HSTS max-age
+
+### Changed
+
+- Added semicolons in README
+- Make some Errors more specific
+
+### Removed
+
+- Removed all comment headers; refer to the readme
+
+### Fixed
+
+- `helmet()` was having issues
+- Fixed Syntax errors in README
+
+This changelog was created after the release of 0.3.1.

--- a/backend/node_modules/helmet/LICENSE
+++ b/backend/node_modules/helmet/LICENSE
@@ -1,0 +1,22 @@
+The MIT License
+
+Copyright (c) 2012-2022 Evan Hahn, Adam Baldwin
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/backend/node_modules/helmet/README.md
+++ b/backend/node_modules/helmet/README.md
@@ -1,0 +1,709 @@
+# Helmet
+
+[![npm version](https://badge.fury.io/js/helmet.svg)](https://badge.fury.io/js/helmet)
+[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fhelmetjs%2Fhelmet.svg?type=shield)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fhelmetjs%2Fhelmet?ref=badge_shield)
+
+Helmet helps you secure your Express apps by setting various HTTP headers. _It's not a silver bullet_, but it can help!
+
+## Quick start
+
+First, run `npm install helmet` for your app. Then, in an Express app:
+
+```js
+const express = require("express");
+const helmet = require("helmet");
+
+const app = express();
+
+app.use(helmet());
+
+// ...
+```
+
+You can also use ECMAScript modules if you prefer.
+
+```js
+import helmet from "helmet";
+
+const app = express();
+
+app.use(helmet());
+```
+
+By default, Helmet sets the following headers:
+
+```http
+Content-Security-Policy: default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests
+Cross-Origin-Embedder-Policy: require-corp
+Cross-Origin-Opener-Policy: same-origin
+Cross-Origin-Resource-Policy: same-origin
+Origin-Agent-Cluster: ?1
+Referrer-Policy: no-referrer
+Strict-Transport-Security: max-age=15552000; includeSubDomains
+X-Content-Type-Options: nosniff
+X-DNS-Prefetch-Control: off
+X-Download-Options: noopen
+X-Frame-Options: SAMEORIGIN
+X-Permitted-Cross-Domain-Policies: none
+X-XSS-Protection: 0
+```
+
+To set custom options for a header, add options like this:
+
+```js
+// This sets custom options for the `referrerPolicy` middleware.
+app.use(
+  helmet({
+    referrerPolicy: { policy: "no-referrer" },
+  })
+);
+```
+
+You can also disable a middleware:
+
+```js
+// This disables the `contentSecurityPolicy` middleware but keeps the rest.
+app.use(
+  helmet({
+    contentSecurityPolicy: false,
+  })
+);
+```
+
+## How it works
+
+Helmet is [Express](https://expressjs.com) middleware. (It also works with [Connect](https://github.com/senchalabs/connect) or [no library at all](https://github.com/helmetjs/helmet/wiki/How-to-use-Helmet-without-Express)! If you need support for other frameworks or languages, [see this list](https://helmetjs.github.io/see-also/).)
+
+The top-level `helmet` function is a wrapper around 15 smaller middlewares.
+
+In other words, these two code snippets are equivalent:
+
+```js
+import helmet from "helmet";
+
+// ...
+
+app.use(helmet());
+```
+
+```js
+import * as helmet from "helmet";
+
+// ...
+
+app.use(helmet.contentSecurityPolicy());
+app.use(helmet.crossOriginEmbedderPolicy());
+app.use(helmet.crossOriginOpenerPolicy());
+app.use(helmet.crossOriginResourcePolicy());
+app.use(helmet.dnsPrefetchControl());
+app.use(helmet.expectCt());
+app.use(helmet.frameguard());
+app.use(helmet.hidePoweredBy());
+app.use(helmet.hsts());
+app.use(helmet.ieNoOpen());
+app.use(helmet.noSniff());
+app.use(helmet.originAgentCluster());
+app.use(helmet.permittedCrossDomainPolicies());
+app.use(helmet.referrerPolicy());
+app.use(helmet.xssFilter());
+```
+
+## Reference
+
+<details>
+<summary><code>helmet(options)</code></summary>
+
+Helmet is the top-level middleware for this module, including all 15 others.
+
+```js
+// Includes all 15 middlewares
+app.use(helmet());
+```
+
+If you want to disable one, pass options to `helmet`. For example, to disable `frameguard`:
+
+```js
+// Includes 14 out of 15 middlewares, skipping `helmet.frameguard`
+app.use(
+  helmet({
+    frameguard: false,
+  })
+);
+```
+
+Most of the middlewares have options, which are documented in more detail below. For example, to pass `{ action: "deny" }` to `frameguard`:
+
+```js
+// Includes all 15 middlewares, setting an option for `helmet.frameguard`
+app.use(
+  helmet({
+    frameguard: {
+      action: "deny",
+    },
+  })
+);
+```
+
+Each middleware's name is listed below.
+
+</details>
+
+<details>
+<summary><code>helmet.contentSecurityPolicy(options)</code></summary>
+
+Default:
+
+```http
+Content-Security-Policy: default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests
+```
+
+`helmet.contentSecurityPolicy` sets the `Content-Security-Policy` header which helps mitigate cross-site scripting attacks, among other things. See [MDN's introductory article on Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP).
+
+This middleware performs very little validation. You should rely on CSP checkers like [CSP Evaluator](https://csp-evaluator.withgoogle.com/) instead.
+
+`options.directives` is an object. Each key is a directive name in camel case (such as `defaultSrc`) or kebab case (such as `default-src`). Each value is an iterable (usually an array) of strings or functions for that directive. If a function appears in the iterable, it will be called with the request and response. The `default-src` can be explicitly disabled by setting its value to `helmet.contentSecurityPolicy.dangerouslyDisableDefaultSrc`.
+
+These directives are merged into a default policy, which you can disable by setting `options.useDefaults` to `false`. Here is the default policy (whitespace added for readability):
+
+    default-src 'self';
+    base-uri 'self';
+    font-src 'self' https: data:;
+    form-action 'self';
+    frame-ancestors 'self';
+    img-src 'self' data:;
+    object-src 'none';
+    script-src 'self';
+    script-src-attr 'none';
+    style-src 'self' https: 'unsafe-inline';
+    upgrade-insecure-requests
+
+`options.reportOnly` is a boolean, defaulting to `false`. If `true`, [the `Content-Security-Policy-Report-Only` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only) will be set instead. If you want to set _both_ the normal and `Report-Only` headers, see [this code snippet](https://github.com/helmetjs/helmet/issues/351#issuecomment-1015498560).
+
+You can also get the default directives object with `helmet.contentSecurityPolicy.getDefaultDirectives()`.
+
+Examples:
+
+```js
+// Sets all of the defaults, but overrides `script-src` and disables the default `style-src`
+app.use(
+  helmet.contentSecurityPolicy({
+    directives: {
+      "script-src": ["'self'", "example.com"],
+      "style-src": null,
+    },
+  })
+);
+
+// Sets "Content-Security-Policy: default-src 'self';script-src 'self' example.com;object-src 'none';upgrade-insecure-requests"
+app.use(
+  helmet.contentSecurityPolicy({
+    useDefaults: false,
+    directives: {
+      defaultSrc: ["'self'"],
+      scriptSrc: ["'self'", "example.com"],
+      objectSrc: ["'none'"],
+      upgradeInsecureRequests: [],
+    },
+  })
+);
+
+// Sets the "Content-Security-Policy-Report-Only" header instead
+app.use(
+  helmet.contentSecurityPolicy({
+    directives: {
+      /* ... */
+    },
+    reportOnly: true,
+  })
+);
+
+// Sets the `script-src` directive to "'self' 'nonce-e33ccde670f149c1789b1e1e113b0916'" (or similar)
+app.use((req, res, next) => {
+  res.locals.cspNonce = crypto.randomBytes(16).toString("hex");
+  next();
+});
+app.use(
+  helmet.contentSecurityPolicy({
+    directives: {
+      scriptSrc: ["'self'", (req, res) => `'nonce-${res.locals.cspNonce}'`],
+    },
+  })
+);
+
+// Sets "Content-Security-Policy: script-src 'self'"
+app.use(
+  helmet.contentSecurityPolicy({
+    useDefaults: false,
+    directives: {
+      "default-src": helmet.contentSecurityPolicy.dangerouslyDisableDefaultSrc,
+      "script-src": ["'self'"],
+    },
+  })
+);
+
+// Sets the `frame-ancestors` directive to "'none'"
+// See also: `helmet.frameguard`
+app.use(
+  helmet.contentSecurityPolicy({
+    directives: {
+      frameAncestors: ["'none'"],
+    },
+  })
+);
+```
+
+You can install this module separately as `helmet-csp`.
+
+</details>
+
+<details>
+<summary><code>helmet.crossOriginEmbedderPolicy(options)</code></summary>
+
+Default:
+
+```http
+Cross-Origin-Embedder-Policy: require-corp
+```
+
+`helmet.crossOriginEmbedderPolicy` sets the `Cross-Origin-Embedder-Policy` header to `require-corp`. See [MDN's article on this header](https://developer.cdn.mozilla.net/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy) for more.
+
+Standalone example:
+
+```js
+// Sets "Cross-Origin-Embedder-Policy: require-corp"
+app.use(helmet.crossOriginEmbedderPolicy());
+
+// Sets "Cross-Origin-Embedder-Policy: credentialless"
+app.use(helmet.crossOriginEmbedderPolicy({ policy: "credentialless" }));
+```
+
+You can't install this module separately.
+
+</details>
+
+<details>
+<summary><code>helmet.crossOriginOpenerPolicy()</code></summary>
+
+```http
+Cross-Origin-Opener-Policy: same-origin
+```
+
+`helmet.crossOriginOpenerPolicy` sets the `Cross-Origin-Opener-Policy` header. For more, see [MDN's article on this header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy).
+
+Example usage with Helmet:
+
+```js
+// Uses the default Helmet options and adds the `crossOriginOpenerPolicy` middleware.
+
+// Sets "Cross-Origin-Opener-Policy: same-origin"
+app.use(helmet({ crossOriginOpenerPolicy: true }));
+
+// Sets "Cross-Origin-Opener-Policy: same-origin-allow-popups"
+app.use(
+  helmet({ crossOriginOpenerPolicy: { policy: "same-origin-allow-popups" } })
+);
+```
+
+Standalone example:
+
+```js
+// Sets "Cross-Origin-Opener-Policy: same-origin"
+app.use(helmet.crossOriginOpenerPolicy());
+
+// Sets "Cross-Origin-Opener-Policy: same-origin-allow-popups"
+app.use(helmet.crossOriginOpenerPolicy({ policy: "same-origin-allow-popups" }));
+
+// Sets "unsafe-none-Opener-Policy: unsafe-none"
+app.use(helmet.crossOriginOpenerPolicy({ policy: "unsafe-none" }));
+```
+
+You can't install this module separately.
+
+</details>
+
+<details>
+<summary><code>helmet.crossOriginResourcePolicy()</code></summary>
+
+Default:
+
+```http
+Cross-Origin-Resource-Policy: same-origin
+```
+
+`helmet.crossOriginResourcePolicy` sets the `Cross-Origin-Resource-Policy` header. For more, see ["Consider deploying Cross-Origin Resource Policy](https://resourcepolicy.fyi/) and [MDN's article on this header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy).
+
+Example usage with Helmet:
+
+```js
+// Uses the default Helmet options and adds the `crossOriginResourcePolicy` middleware.
+
+// Sets "Cross-Origin-Resource-Policy: same-origin"
+app.use(helmet({ crossOriginResourcePolicy: true }));
+
+// Sets "Cross-Origin-Resource-Policy: same-site"
+app.use(helmet({ crossOriginResourcePolicy: { policy: "same-site" } }));
+```
+
+Standalone example:
+
+```js
+// Sets "Cross-Origin-Resource-Policy: same-origin"
+app.use(helmet.crossOriginResourcePolicy());
+
+// Sets "Cross-Origin-Resource-Policy: same-site"
+app.use(helmet.crossOriginResourcePolicy({ policy: "same-site" }));
+
+// Sets "Cross-Origin-Resource-Policy: cross-origin"
+app.use(helmet.crossOriginResourcePolicy({ policy: "cross-origin" }));
+```
+
+You can install this module separately as `cross-origin-resource-policy`.
+
+</details>
+
+<details>
+<summary><code>helmet.expectCt(options)</code></summary>
+
+Default:
+
+```http
+Expect-CT: max-age=0
+```
+
+`helmet.expectCt` sets the `Expect-CT` header which helps mitigate misissued SSL certificates. See [MDN's article on Certificate Transparency](https://developer.mozilla.org/en-US/docs/Web/Security/Certificate_Transparency) and the [`Expect-CT` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Expect-CT) for more.
+
+`Expect-CT` is no longer useful for new browsers in 2022. Therefore, `helmet.expectCt` is deprecated and will be removed in the next major version of Helmet. However, it can still be used in this version of Helmet.
+
+`options.maxAge` is the number of seconds to expect Certificate Transparency. It defaults to `0`.
+
+`options.enforce` is a boolean. If `true`, the user agent (usually a browser) should refuse future connections that violate its Certificate Transparency policy. Defaults to `false`.
+
+`options.reportUri` is a string. If set, complying user agents will report Certificate Transparency failures to this URL. Unset by default.
+
+Examples:
+
+```js
+// Sets "Expect-CT: max-age=86400"
+app.use(
+  helmet.expectCt({
+    maxAge: 86400,
+  })
+);
+
+// Sets "Expect-CT: max-age=86400, enforce, report-uri="https://example.com/report"
+app.use(
+  helmet.expectCt({
+    maxAge: 86400,
+    enforce: true,
+    reportUri: "https://example.com/report",
+  })
+);
+```
+
+You can install this module separately as `expect-ct`.
+
+</details>
+
+<details>
+<summary><code>helmet.referrerPolicy(options)</code></summary>
+
+Default:
+
+```http
+Referrer-Policy: no-referrer
+```
+
+`helmet.referrerPolicy` sets the `Referrer-Policy` header which controls what information is set in [the `Referer` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer). See ["Referer header: privacy and security concerns"](https://developer.mozilla.org/en-US/docs/Web/Security/Referer_header:_privacy_and_security_concerns) and [the header's documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy) on MDN for more.
+
+`options.policy` is a string or array of strings representing the policy. If passed as an array, it will be joined with commas, which is useful when setting [a fallback policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy#Specifying_a_fallback_policy). It defaults to `no-referrer`.
+
+Examples:
+
+```js
+// Sets "Referrer-Policy: no-referrer"
+app.use(
+  helmet.referrerPolicy({
+    policy: "no-referrer",
+  })
+);
+
+// Sets "Referrer-Policy: origin,unsafe-url"
+app.use(
+  helmet.referrerPolicy({
+    policy: ["origin", "unsafe-url"],
+  })
+);
+```
+
+You can install this module separately as `referrer-policy`.
+
+</details>
+
+<details>
+<summary><code>helmet.hsts(options)</code></summary>
+
+Default:
+
+```http
+Strict-Transport-Security: max-age=15552000; includeSubDomains
+```
+
+`helmet.hsts` sets the `Strict-Transport-Security` header which tells browsers to prefer HTTPS over insecure HTTP. See [the documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) for more.
+
+`options.maxAge` is the number of seconds browsers should remember to prefer HTTPS. If passed a non-integer, the value is rounded down. It defaults to `15552000`, which is 180 days.
+
+`options.includeSubDomains` is a boolean which dictates whether to include the `includeSubDomains` directive, which makes this policy extend to subdomains. It defaults to `true`.
+
+`options.preload` is a boolean. If true, it adds the `preload` directive, expressing intent to add your HSTS policy to browsers. See [the "Preloading Strict Transport Security" section on MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security#Preloading_Strict_Transport_Security) for more. It defaults to `false`.
+
+Examples:
+
+```js
+// Sets "Strict-Transport-Security: max-age=123456; includeSubDomains"
+app.use(
+  helmet.hsts({
+    maxAge: 123456,
+  })
+);
+
+// Sets "Strict-Transport-Security: max-age=123456"
+app.use(
+  helmet.hsts({
+    maxAge: 123456,
+    includeSubDomains: false,
+  })
+);
+
+// Sets "Strict-Transport-Security: max-age=123456; includeSubDomains; preload"
+app.use(
+  helmet.hsts({
+    maxAge: 63072000,
+    preload: true,
+  })
+);
+```
+
+You can install this module separately as `hsts`.
+
+</details>
+
+<details>
+<summary><code>helmet.noSniff()</code></summary>
+
+Default:
+
+```http
+X-Content-Type-Options: nosniff
+```
+
+`helmet.noSniff` sets the `X-Content-Type-Options` header to `nosniff`. This mitigates [MIME type sniffing](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#MIME_sniffing) which can cause security vulnerabilities. See [documentation for this header on MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options) for more.
+
+This middleware takes no options.
+
+Example:
+
+```js
+// Sets "X-Content-Type-Options: nosniff"
+app.use(helmet.noSniff());
+```
+
+You can install this module separately as `dont-sniff-mimetype`.
+
+</details>
+
+<details>
+<summary><code>helmet.originAgentCluster()</code></summary>
+
+Default:
+
+```http
+Origin-Agent-Cluster: ?1
+```
+
+`helmet.originAgentCluster` sets the `Origin-Agent-Cluster` header, which provides a mechanism to allow web applications to isolate their origins. Read more about it [in the spec](https://whatpr.org/html/6214/origin.html#origin-keyed-agent-clusters).
+
+Standalone example:
+
+```js
+// Sets "Origin-Agent-Cluster: ?1"
+app.use(helmet.originAgentCluster());
+```
+
+You can't install this module separately.
+
+</details>
+
+<details>
+<summary><code>helmet.dnsPrefetchControl(options)</code></summary>
+
+Default:
+
+```http
+X-DNS-Prefetch-Control: off
+```
+
+`helmet.dnsPrefetchControl` sets the `X-DNS-Prefetch-Control` header to help control DNS prefetching, which can improve user privacy at the expense of performance. See [documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-DNS-Prefetch-Control) for more.
+
+`options.allow` is a boolean dictating whether to enable DNS prefetching. It defaults to `false`.
+
+Examples:
+
+```js
+// Sets "X-DNS-Prefetch-Control: off"
+app.use(
+  helmet.dnsPrefetchControl({
+    allow: false,
+  })
+);
+
+// Sets "X-DNS-Prefetch-Control: on"
+app.use(
+  helmet.dnsPrefetchControl({
+    allow: true,
+  })
+);
+```
+
+You can install this module separately as `dns-prefetch-control`.
+
+</details>
+
+<details>
+<summary><code>helmet.ieNoOpen()</code></summary>
+
+Default:
+
+```http
+X-Download-Options: noopen
+```
+
+`helmet.ieNoOpen` sets the `X-Download-Options` header, which is specific to Internet Explorer 8. It forces potentially-unsafe downloads to be saved, mitigating execution of HTML in your site's context. For more, see [this old post on MSDN](https://docs.microsoft.com/en-us/archive/blogs/ie/ie8-security-part-v-comprehensive-protection).
+
+This middleware takes no options.
+
+Examples:
+
+```js
+// Sets "X-Download-Options: noopen"
+app.use(helmet.ieNoOpen());
+```
+
+You can install this module separately as `ienoopen`.
+
+</details>
+
+<details>
+<summary><code>helmet.frameguard(options)</code></summary>
+
+Default:
+
+```http
+X-Frame-Options: SAMEORIGIN
+```
+
+`helmet.frameguard` sets the `X-Frame-Options` header to help you mitigate [clickjacking attacks](https://en.wikipedia.org/wiki/Clickjacking). This header is superseded by [the `frame-ancestors` Content Security Policy directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors) but is still useful on old browsers. For more, see `helmet.contentSecurityPolicy`, as well as [the documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options).
+
+`options.action` is a string that specifies which directive to use—either `DENY` or `SAMEORIGIN`. (A legacy directive, `ALLOW-FROM`, is not supported by this middleware. [Read more here.](https://github.com/helmetjs/helmet/wiki/How-to-use-X%E2%80%93Frame%E2%80%93Options's-%60ALLOW%E2%80%93FROM%60-directive)) It defaults to `SAMEORIGIN`.
+
+Examples:
+
+```js
+// Sets "X-Frame-Options: DENY"
+app.use(
+  helmet.frameguard({
+    action: "deny",
+  })
+);
+
+// Sets "X-Frame-Options: SAMEORIGIN"
+app.use(
+  helmet.frameguard({
+    action: "sameorigin",
+  })
+);
+```
+
+You can install this module separately as `frameguard`.
+
+</details>
+
+<details>
+<summary><code>helmet.permittedCrossDomainPolicies(options)</code></summary>
+
+Default:
+
+```http
+X-Permitted-Cross-Domain-Policies: none
+```
+
+`helmet.permittedCrossDomainPolicies` sets the `X-Permitted-Cross-Domain-Policies` header, which tells some clients (mostly Adobe products) your domain's policy for loading cross-domain content. See [the description on OWASP](https://owasp.org/www-project-secure-headers/) for more.
+
+`options.permittedPolicies` is a string that must be `"none"`, `"master-only"`, `"by-content-type"`, or `"all"`. It defaults to `"none"`.
+
+Examples:
+
+```js
+// Sets "X-Permitted-Cross-Domain-Policies: none"
+app.use(
+  helmet.permittedCrossDomainPolicies({
+    permittedPolicies: "none",
+  })
+);
+
+// Sets "X-Permitted-Cross-Domain-Policies: by-content-type"
+app.use(
+  helmet.permittedCrossDomainPolicies({
+    permittedPolicies: "by-content-type",
+  })
+);
+```
+
+You can install this module separately as `helmet-crossdomain`.
+
+</details>
+
+<details>
+<summary><code>helmet.hidePoweredBy()</code></summary>
+
+Default: the `X-Powered-By` header, if present, is omitted.
+
+`helmet.hidePoweredBy` removes the `X-Powered-By` header, which is set by default in some frameworks (like Express). Removing the header offers very limited security benefits (see [this discussion](https://github.com/expressjs/express/pull/2813#issuecomment-159270428)) and is mostly removed to save bandwidth.
+
+This middleware takes no options.
+
+Note: [Express has a built-in way to disable the `X-Powered-By` header](https://stackoverflow.com/a/12484642/804100), which you may wish to use instead of this middleware.
+
+Examples:
+
+```js
+// Removes the X-Powered-By header if it was set.
+app.use(helmet.hidePoweredBy());
+```
+
+You can install this module separately as `hide-powered-by`.
+
+</details>
+
+<details>
+<summary><code>helmet.xssFilter()</code></summary>
+
+Default:
+
+```http
+X-XSS-Protection: 0
+```
+
+`helmet.xssFilter` disables browsers' buggy cross-site scripting filter by setting the `X-XSS-Protection` header to `0`. See [discussion about disabling the header here](https://github.com/helmetjs/helmet/issues/230) and [documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection).
+
+This middleware takes no options.
+
+Examples:
+
+```js
+// Sets "X-XSS-Protection: 0"
+app.use(helmet.xssFilter());
+```
+
+You can install this module separately as `x-xss-protection`.
+
+</details>

--- a/backend/node_modules/helmet/SECURITY.md
+++ b/backend/node_modules/helmet/SECURITY.md
@@ -1,0 +1,7 @@
+# Security issue reporting & disclosure process
+
+If you feel you have found a security issue or concern with Helmet, please reach out to the maintainers.
+
+Email Evan Hahn at <me@evanhahn.com> or Adam Baldwin at <adam@npmjs.com>.
+
+We will try to communicate in a timely manner and address your concerns.

--- a/backend/node_modules/helmet/dist/cjs/index.js
+++ b/backend/node_modules/helmet/dist/cjs/index.js
@@ -1,0 +1,471 @@
+"use strict"
+
+Object.defineProperty(exports, "__esModule", { value: true })
+
+const dangerouslyDisableDefaultSrc = Symbol("dangerouslyDisableDefaultSrc")
+const DEFAULT_DIRECTIVES = {
+	"default-src": ["'self'"],
+	"base-uri": ["'self'"],
+	"font-src": ["'self'", "https:", "data:"],
+	"form-action": ["'self'"],
+	"frame-ancestors": ["'self'"],
+	"img-src": ["'self'", "data:"],
+	"object-src": ["'none'"],
+	"script-src": ["'self'"],
+	"script-src-attr": ["'none'"],
+	"style-src": ["'self'", "https:", "'unsafe-inline'"],
+	"upgrade-insecure-requests": []
+}
+const getDefaultDirectives = () => Object.assign({}, DEFAULT_DIRECTIVES)
+const dashify = str => str.replace(/[A-Z]/g, capitalLetter => "-" + capitalLetter.toLowerCase())
+const isDirectiveValueInvalid = directiveValue => /;|,/.test(directiveValue)
+const has = (obj, key) => Object.prototype.hasOwnProperty.call(obj, key)
+function normalizeDirectives(options) {
+	const defaultDirectives = getDefaultDirectives()
+	const { useDefaults = true, directives: rawDirectives = defaultDirectives } = options
+	const result = new Map()
+	const directiveNamesSeen = new Set()
+	const directivesExplicitlyDisabled = new Set()
+	for (const rawDirectiveName in rawDirectives) {
+		if (!has(rawDirectives, rawDirectiveName)) {
+			continue
+		}
+		if (rawDirectiveName.length === 0 || /[^a-zA-Z0-9-]/.test(rawDirectiveName)) {
+			throw new Error(`Content-Security-Policy received an invalid directive name ${JSON.stringify(rawDirectiveName)}`)
+		}
+		const directiveName = dashify(rawDirectiveName)
+		if (directiveNamesSeen.has(directiveName)) {
+			throw new Error(`Content-Security-Policy received a duplicate directive ${JSON.stringify(directiveName)}`)
+		}
+		directiveNamesSeen.add(directiveName)
+		const rawDirectiveValue = rawDirectives[rawDirectiveName]
+		let directiveValue
+		if (rawDirectiveValue === null) {
+			if (directiveName === "default-src") {
+				throw new Error("Content-Security-Policy needs a default-src but it was set to `null`. If you really want to disable it, set it to `contentSecurityPolicy.dangerouslyDisableDefaultSrc`.")
+			}
+			directivesExplicitlyDisabled.add(directiveName)
+			continue
+		} else if (typeof rawDirectiveValue === "string") {
+			directiveValue = [rawDirectiveValue]
+		} else if (!rawDirectiveValue) {
+			throw new Error(`Content-Security-Policy received an invalid directive value for ${JSON.stringify(directiveName)}`)
+		} else if (rawDirectiveValue === dangerouslyDisableDefaultSrc) {
+			if (directiveName === "default-src") {
+				directivesExplicitlyDisabled.add("default-src")
+				continue
+			} else {
+				throw new Error(`Content-Security-Policy: tried to disable ${JSON.stringify(directiveName)} as if it were default-src; simply omit the key`)
+			}
+		} else {
+			directiveValue = rawDirectiveValue
+		}
+		for (const element of directiveValue) {
+			if (typeof element === "string" && isDirectiveValueInvalid(element)) {
+				throw new Error(`Content-Security-Policy received an invalid directive value for ${JSON.stringify(directiveName)}`)
+			}
+		}
+		result.set(directiveName, directiveValue)
+	}
+	if (useDefaults) {
+		Object.entries(defaultDirectives).forEach(([defaultDirectiveName, defaultDirectiveValue]) => {
+			if (!result.has(defaultDirectiveName) && !directivesExplicitlyDisabled.has(defaultDirectiveName)) {
+				result.set(defaultDirectiveName, defaultDirectiveValue)
+			}
+		})
+	}
+	if (!result.size) {
+		throw new Error("Content-Security-Policy has no directives. Either set some or disable the header")
+	}
+	if (!result.has("default-src") && !directivesExplicitlyDisabled.has("default-src")) {
+		throw new Error("Content-Security-Policy needs a default-src but none was provided. If you really want to disable it, set it to `contentSecurityPolicy.dangerouslyDisableDefaultSrc`.")
+	}
+	return result
+}
+function getHeaderValue(req, res, normalizedDirectives) {
+	let err
+	const result = []
+	normalizedDirectives.forEach((rawDirectiveValue, directiveName) => {
+		let directiveValue = ""
+		for (const element of rawDirectiveValue) {
+			directiveValue += " " + (element instanceof Function ? element(req, res) : element)
+		}
+		if (!directiveValue) {
+			result.push(directiveName)
+		} else if (isDirectiveValueInvalid(directiveValue)) {
+			err = new Error(`Content-Security-Policy received an invalid directive value for ${JSON.stringify(directiveName)}`)
+		} else {
+			result.push(`${directiveName}${directiveValue}`)
+		}
+	})
+	return err ? err : result.join(";")
+}
+const contentSecurityPolicy = function contentSecurityPolicy(options = {}) {
+	const headerName = options.reportOnly ? "Content-Security-Policy-Report-Only" : "Content-Security-Policy"
+	const normalizedDirectives = normalizeDirectives(options)
+	return function contentSecurityPolicyMiddleware(req, res, next) {
+		const result = getHeaderValue(req, res, normalizedDirectives)
+		if (result instanceof Error) {
+			next(result)
+		} else {
+			res.setHeader(headerName, result)
+			next()
+		}
+	}
+}
+contentSecurityPolicy.getDefaultDirectives = getDefaultDirectives
+contentSecurityPolicy.dangerouslyDisableDefaultSrc = dangerouslyDisableDefaultSrc
+
+const ALLOWED_POLICIES$2 = new Set(["require-corp", "credentialless"])
+function getHeaderValueFromOptions$7({ policy = "require-corp" }) {
+	if (ALLOWED_POLICIES$2.has(policy)) {
+		return policy
+	} else {
+		throw new Error(`Cross-Origin-Embedder-Policy does not support the ${JSON.stringify(policy)} policy`)
+	}
+}
+function crossOriginEmbedderPolicy(options = {}) {
+	const headerValue = getHeaderValueFromOptions$7(options)
+	return function crossOriginEmbedderPolicyMiddleware(_req, res, next) {
+		res.setHeader("Cross-Origin-Embedder-Policy", headerValue)
+		next()
+	}
+}
+
+const ALLOWED_POLICIES$1 = new Set(["same-origin", "same-origin-allow-popups", "unsafe-none"])
+function getHeaderValueFromOptions$6({ policy = "same-origin" }) {
+	if (ALLOWED_POLICIES$1.has(policy)) {
+		return policy
+	} else {
+		throw new Error(`Cross-Origin-Opener-Policy does not support the ${JSON.stringify(policy)} policy`)
+	}
+}
+function crossOriginOpenerPolicy(options = {}) {
+	const headerValue = getHeaderValueFromOptions$6(options)
+	return function crossOriginOpenerPolicyMiddleware(_req, res, next) {
+		res.setHeader("Cross-Origin-Opener-Policy", headerValue)
+		next()
+	}
+}
+
+const ALLOWED_POLICIES = new Set(["same-origin", "same-site", "cross-origin"])
+function getHeaderValueFromOptions$5({ policy = "same-origin" }) {
+	if (ALLOWED_POLICIES.has(policy)) {
+		return policy
+	} else {
+		throw new Error(`Cross-Origin-Resource-Policy does not support the ${JSON.stringify(policy)} policy`)
+	}
+}
+function crossOriginResourcePolicy(options = {}) {
+	const headerValue = getHeaderValueFromOptions$5(options)
+	return function crossOriginResourcePolicyMiddleware(_req, res, next) {
+		res.setHeader("Cross-Origin-Resource-Policy", headerValue)
+		next()
+	}
+}
+
+function parseMaxAge$1(value = 0) {
+	if (value >= 0 && Number.isFinite(value)) {
+		return Math.floor(value)
+	} else {
+		throw new Error(`Expect-CT: ${JSON.stringify(value)} is not a valid value for maxAge. Please choose a positive integer.`)
+	}
+}
+function getHeaderValueFromOptions$4(options) {
+	const directives = [`max-age=${parseMaxAge$1(options.maxAge)}`]
+	if (options.enforce) {
+		directives.push("enforce")
+	}
+	if (options.reportUri) {
+		directives.push(`report-uri="${options.reportUri}"`)
+	}
+	return directives.join(", ")
+}
+function expectCt(options = {}) {
+	const headerValue = getHeaderValueFromOptions$4(options)
+	return function expectCtMiddleware(_req, res, next) {
+		res.setHeader("Expect-CT", headerValue)
+		next()
+	}
+}
+
+function originAgentCluster() {
+	return function originAgentClusterMiddleware(_req, res, next) {
+		res.setHeader("Origin-Agent-Cluster", "?1")
+		next()
+	}
+}
+
+const ALLOWED_TOKENS = new Set(["no-referrer", "no-referrer-when-downgrade", "same-origin", "origin", "strict-origin", "origin-when-cross-origin", "strict-origin-when-cross-origin", "unsafe-url", ""])
+function getHeaderValueFromOptions$3({ policy = ["no-referrer"] }) {
+	const tokens = typeof policy === "string" ? [policy] : policy
+	if (tokens.length === 0) {
+		throw new Error("Referrer-Policy received no policy tokens")
+	}
+	const tokensSeen = new Set()
+	tokens.forEach(token => {
+		if (!ALLOWED_TOKENS.has(token)) {
+			throw new Error(`Referrer-Policy received an unexpected policy token ${JSON.stringify(token)}`)
+		} else if (tokensSeen.has(token)) {
+			throw new Error(`Referrer-Policy received a duplicate policy token ${JSON.stringify(token)}`)
+		}
+		tokensSeen.add(token)
+	})
+	return tokens.join(",")
+}
+function referrerPolicy(options = {}) {
+	const headerValue = getHeaderValueFromOptions$3(options)
+	return function referrerPolicyMiddleware(_req, res, next) {
+		res.setHeader("Referrer-Policy", headerValue)
+		next()
+	}
+}
+
+const DEFAULT_MAX_AGE = 180 * 24 * 60 * 60
+function parseMaxAge(value = DEFAULT_MAX_AGE) {
+	if (value >= 0 && Number.isFinite(value)) {
+		return Math.floor(value)
+	} else {
+		throw new Error(`Strict-Transport-Security: ${JSON.stringify(value)} is not a valid value for maxAge. Please choose a positive integer.`)
+	}
+}
+function getHeaderValueFromOptions$2(options) {
+	if ("maxage" in options) {
+		throw new Error("Strict-Transport-Security received an unsupported property, `maxage`. Did you mean to pass `maxAge`?")
+	}
+	if ("includeSubdomains" in options) {
+		console.warn('Strict-Transport-Security middleware should use `includeSubDomains` instead of `includeSubdomains`. (The correct one has an uppercase "D".)')
+	}
+	if ("setIf" in options) {
+		console.warn("Strict-Transport-Security middleware no longer supports the `setIf` parameter. See the documentation and <https://github.com/helmetjs/helmet/wiki/Conditionally-using-middleware> if you need help replicating this behavior.")
+	}
+	const directives = [`max-age=${parseMaxAge(options.maxAge)}`]
+	if (options.includeSubDomains === undefined || options.includeSubDomains) {
+		directives.push("includeSubDomains")
+	}
+	if (options.preload) {
+		directives.push("preload")
+	}
+	return directives.join("; ")
+}
+function strictTransportSecurity(options = {}) {
+	const headerValue = getHeaderValueFromOptions$2(options)
+	return function strictTransportSecurityMiddleware(_req, res, next) {
+		res.setHeader("Strict-Transport-Security", headerValue)
+		next()
+	}
+}
+
+function xContentTypeOptions() {
+	return function xContentTypeOptionsMiddleware(_req, res, next) {
+		res.setHeader("X-Content-Type-Options", "nosniff")
+		next()
+	}
+}
+
+function xDnsPrefetchControl(options = {}) {
+	const headerValue = options.allow ? "on" : "off"
+	return function xDnsPrefetchControlMiddleware(_req, res, next) {
+		res.setHeader("X-DNS-Prefetch-Control", headerValue)
+		next()
+	}
+}
+
+function xDownloadOptions() {
+	return function xDownloadOptionsMiddleware(_req, res, next) {
+		res.setHeader("X-Download-Options", "noopen")
+		next()
+	}
+}
+
+function getHeaderValueFromOptions$1({ action = "sameorigin" }) {
+	const normalizedAction = typeof action === "string" ? action.toUpperCase() : action
+	switch (normalizedAction) {
+		case "SAME-ORIGIN":
+			return "SAMEORIGIN"
+		case "DENY":
+		case "SAMEORIGIN":
+			return normalizedAction
+		default:
+			throw new Error(`X-Frame-Options received an invalid action ${JSON.stringify(action)}`)
+	}
+}
+function xFrameOptions(options = {}) {
+	const headerValue = getHeaderValueFromOptions$1(options)
+	return function xFrameOptionsMiddleware(_req, res, next) {
+		res.setHeader("X-Frame-Options", headerValue)
+		next()
+	}
+}
+
+const ALLOWED_PERMITTED_POLICIES = new Set(["none", "master-only", "by-content-type", "all"])
+function getHeaderValueFromOptions({ permittedPolicies = "none" }) {
+	if (ALLOWED_PERMITTED_POLICIES.has(permittedPolicies)) {
+		return permittedPolicies
+	} else {
+		throw new Error(`X-Permitted-Cross-Domain-Policies does not support ${JSON.stringify(permittedPolicies)}`)
+	}
+}
+function xPermittedCrossDomainPolicies(options = {}) {
+	const headerValue = getHeaderValueFromOptions(options)
+	return function xPermittedCrossDomainPoliciesMiddleware(_req, res, next) {
+		res.setHeader("X-Permitted-Cross-Domain-Policies", headerValue)
+		next()
+	}
+}
+
+function xPoweredBy() {
+	return function xPoweredByMiddleware(_req, res, next) {
+		res.removeHeader("X-Powered-By")
+		next()
+	}
+}
+
+function xXssProtection() {
+	return function xXssProtectionMiddleware(_req, res, next) {
+		res.setHeader("X-XSS-Protection", "0")
+		next()
+	}
+}
+
+function getArgs(option, middlewareConfig = {}) {
+	switch (option) {
+		case undefined:
+		case true:
+			return []
+		case false:
+			return null
+		default:
+			if (middlewareConfig.takesOptions === false) {
+				console.warn(`${middlewareConfig.name} does not take options. Remove the property to silence this warning.`)
+				return []
+			} else {
+				return [option]
+			}
+	}
+}
+function getMiddlewareFunctionsFromOptions(options) {
+	const result = []
+	const contentSecurityPolicyArgs = getArgs(options.contentSecurityPolicy)
+	if (contentSecurityPolicyArgs) {
+		result.push(contentSecurityPolicy(...contentSecurityPolicyArgs))
+	}
+	const crossOriginEmbedderPolicyArgs = getArgs(options.crossOriginEmbedderPolicy)
+	if (crossOriginEmbedderPolicyArgs) {
+		result.push(crossOriginEmbedderPolicy(...crossOriginEmbedderPolicyArgs))
+	}
+	const crossOriginOpenerPolicyArgs = getArgs(options.crossOriginOpenerPolicy)
+	if (crossOriginOpenerPolicyArgs) {
+		result.push(crossOriginOpenerPolicy(...crossOriginOpenerPolicyArgs))
+	}
+	const crossOriginResourcePolicyArgs = getArgs(options.crossOriginResourcePolicy)
+	if (crossOriginResourcePolicyArgs) {
+		result.push(crossOriginResourcePolicy(...crossOriginResourcePolicyArgs))
+	}
+	const xDnsPrefetchControlArgs = getArgs(options.dnsPrefetchControl)
+	if (xDnsPrefetchControlArgs) {
+		result.push(xDnsPrefetchControl(...xDnsPrefetchControlArgs))
+	}
+	const expectCtArgs = options.expectCt && getArgs(options.expectCt)
+	if (expectCtArgs) {
+		result.push(expectCt(...expectCtArgs))
+	}
+	const xFrameOptionsArgs = getArgs(options.frameguard)
+	if (xFrameOptionsArgs) {
+		result.push(xFrameOptions(...xFrameOptionsArgs))
+	}
+	const xPoweredByArgs = getArgs(options.hidePoweredBy, {
+		name: "hidePoweredBy",
+		takesOptions: false
+	})
+	if (xPoweredByArgs) {
+		result.push(xPoweredBy())
+	}
+	const strictTransportSecurityArgs = getArgs(options.hsts)
+	if (strictTransportSecurityArgs) {
+		result.push(strictTransportSecurity(...strictTransportSecurityArgs))
+	}
+	const xDownloadOptionsArgs = getArgs(options.ieNoOpen, {
+		name: "ieNoOpen",
+		takesOptions: false
+	})
+	if (xDownloadOptionsArgs) {
+		result.push(xDownloadOptions())
+	}
+	const xContentTypeOptionsArgs = getArgs(options.noSniff, {
+		name: "noSniff",
+		takesOptions: false
+	})
+	if (xContentTypeOptionsArgs) {
+		result.push(xContentTypeOptions())
+	}
+	const originAgentClusterArgs = getArgs(options.originAgentCluster, {
+		name: "originAgentCluster",
+		takesOptions: false
+	})
+	if (originAgentClusterArgs) {
+		result.push(originAgentCluster())
+	}
+	const xPermittedCrossDomainPoliciesArgs = getArgs(options.permittedCrossDomainPolicies)
+	if (xPermittedCrossDomainPoliciesArgs) {
+		result.push(xPermittedCrossDomainPolicies(...xPermittedCrossDomainPoliciesArgs))
+	}
+	const referrerPolicyArgs = getArgs(options.referrerPolicy)
+	if (referrerPolicyArgs) {
+		result.push(referrerPolicy(...referrerPolicyArgs))
+	}
+	const xXssProtectionArgs = getArgs(options.xssFilter, {
+		name: "xssFilter",
+		takesOptions: false
+	})
+	if (xXssProtectionArgs) {
+		result.push(xXssProtection())
+	}
+	return result
+}
+const helmet = Object.assign(
+	function helmet(options = {}) {
+		var _a
+		if (((_a = options.constructor) === null || _a === void 0 ? void 0 : _a.name) === "IncomingMessage") {
+			throw new Error("It appears you have done something like `app.use(helmet)`, but it should be `app.use(helmet())`.")
+		}
+		const middlewareFunctions = getMiddlewareFunctionsFromOptions(options)
+		return function helmetMiddleware(req, res, next) {
+			let middlewareIndex = 0
+			;(function internalNext(err) {
+				if (err) {
+					next(err)
+					return
+				}
+				const middlewareFunction = middlewareFunctions[middlewareIndex]
+				if (middlewareFunction) {
+					middlewareIndex++
+					middlewareFunction(req, res, internalNext)
+				} else {
+					next()
+				}
+			})()
+		}
+	},
+	{
+		contentSecurityPolicy,
+		crossOriginEmbedderPolicy,
+		crossOriginOpenerPolicy,
+		crossOriginResourcePolicy,
+		dnsPrefetchControl: xDnsPrefetchControl,
+		expectCt,
+		frameguard: xFrameOptions,
+		hidePoweredBy: xPoweredBy,
+		hsts: strictTransportSecurity,
+		ieNoOpen: xDownloadOptions,
+		noSniff: xContentTypeOptions,
+		originAgentCluster,
+		permittedCrossDomainPolicies: xPermittedCrossDomainPolicies,
+		referrerPolicy,
+		xssFilter: xXssProtection
+	}
+)
+exports = helmet
+module.exports = helmet
+
+exports["default"] = helmet

--- a/backend/node_modules/helmet/dist/cjs/package.json
+++ b/backend/node_modules/helmet/dist/cjs/package.json
@@ -1,0 +1,3 @@
+{
+	"type": "commonjs"
+}

--- a/backend/node_modules/helmet/dist/esm/index.js
+++ b/backend/node_modules/helmet/dist/esm/index.js
@@ -1,0 +1,465 @@
+const dangerouslyDisableDefaultSrc = Symbol("dangerouslyDisableDefaultSrc")
+const DEFAULT_DIRECTIVES = {
+	"default-src": ["'self'"],
+	"base-uri": ["'self'"],
+	"font-src": ["'self'", "https:", "data:"],
+	"form-action": ["'self'"],
+	"frame-ancestors": ["'self'"],
+	"img-src": ["'self'", "data:"],
+	"object-src": ["'none'"],
+	"script-src": ["'self'"],
+	"script-src-attr": ["'none'"],
+	"style-src": ["'self'", "https:", "'unsafe-inline'"],
+	"upgrade-insecure-requests": []
+}
+const getDefaultDirectives = () => Object.assign({}, DEFAULT_DIRECTIVES)
+const dashify = str => str.replace(/[A-Z]/g, capitalLetter => "-" + capitalLetter.toLowerCase())
+const isDirectiveValueInvalid = directiveValue => /;|,/.test(directiveValue)
+const has = (obj, key) => Object.prototype.hasOwnProperty.call(obj, key)
+function normalizeDirectives(options) {
+	const defaultDirectives = getDefaultDirectives()
+	const { useDefaults = true, directives: rawDirectives = defaultDirectives } = options
+	const result = new Map()
+	const directiveNamesSeen = new Set()
+	const directivesExplicitlyDisabled = new Set()
+	for (const rawDirectiveName in rawDirectives) {
+		if (!has(rawDirectives, rawDirectiveName)) {
+			continue
+		}
+		if (rawDirectiveName.length === 0 || /[^a-zA-Z0-9-]/.test(rawDirectiveName)) {
+			throw new Error(`Content-Security-Policy received an invalid directive name ${JSON.stringify(rawDirectiveName)}`)
+		}
+		const directiveName = dashify(rawDirectiveName)
+		if (directiveNamesSeen.has(directiveName)) {
+			throw new Error(`Content-Security-Policy received a duplicate directive ${JSON.stringify(directiveName)}`)
+		}
+		directiveNamesSeen.add(directiveName)
+		const rawDirectiveValue = rawDirectives[rawDirectiveName]
+		let directiveValue
+		if (rawDirectiveValue === null) {
+			if (directiveName === "default-src") {
+				throw new Error("Content-Security-Policy needs a default-src but it was set to `null`. If you really want to disable it, set it to `contentSecurityPolicy.dangerouslyDisableDefaultSrc`.")
+			}
+			directivesExplicitlyDisabled.add(directiveName)
+			continue
+		} else if (typeof rawDirectiveValue === "string") {
+			directiveValue = [rawDirectiveValue]
+		} else if (!rawDirectiveValue) {
+			throw new Error(`Content-Security-Policy received an invalid directive value for ${JSON.stringify(directiveName)}`)
+		} else if (rawDirectiveValue === dangerouslyDisableDefaultSrc) {
+			if (directiveName === "default-src") {
+				directivesExplicitlyDisabled.add("default-src")
+				continue
+			} else {
+				throw new Error(`Content-Security-Policy: tried to disable ${JSON.stringify(directiveName)} as if it were default-src; simply omit the key`)
+			}
+		} else {
+			directiveValue = rawDirectiveValue
+		}
+		for (const element of directiveValue) {
+			if (typeof element === "string" && isDirectiveValueInvalid(element)) {
+				throw new Error(`Content-Security-Policy received an invalid directive value for ${JSON.stringify(directiveName)}`)
+			}
+		}
+		result.set(directiveName, directiveValue)
+	}
+	if (useDefaults) {
+		Object.entries(defaultDirectives).forEach(([defaultDirectiveName, defaultDirectiveValue]) => {
+			if (!result.has(defaultDirectiveName) && !directivesExplicitlyDisabled.has(defaultDirectiveName)) {
+				result.set(defaultDirectiveName, defaultDirectiveValue)
+			}
+		})
+	}
+	if (!result.size) {
+		throw new Error("Content-Security-Policy has no directives. Either set some or disable the header")
+	}
+	if (!result.has("default-src") && !directivesExplicitlyDisabled.has("default-src")) {
+		throw new Error("Content-Security-Policy needs a default-src but none was provided. If you really want to disable it, set it to `contentSecurityPolicy.dangerouslyDisableDefaultSrc`.")
+	}
+	return result
+}
+function getHeaderValue(req, res, normalizedDirectives) {
+	let err
+	const result = []
+	normalizedDirectives.forEach((rawDirectiveValue, directiveName) => {
+		let directiveValue = ""
+		for (const element of rawDirectiveValue) {
+			directiveValue += " " + (element instanceof Function ? element(req, res) : element)
+		}
+		if (!directiveValue) {
+			result.push(directiveName)
+		} else if (isDirectiveValueInvalid(directiveValue)) {
+			err = new Error(`Content-Security-Policy received an invalid directive value for ${JSON.stringify(directiveName)}`)
+		} else {
+			result.push(`${directiveName}${directiveValue}`)
+		}
+	})
+	return err ? err : result.join(";")
+}
+const contentSecurityPolicy = function contentSecurityPolicy(options = {}) {
+	const headerName = options.reportOnly ? "Content-Security-Policy-Report-Only" : "Content-Security-Policy"
+	const normalizedDirectives = normalizeDirectives(options)
+	return function contentSecurityPolicyMiddleware(req, res, next) {
+		const result = getHeaderValue(req, res, normalizedDirectives)
+		if (result instanceof Error) {
+			next(result)
+		} else {
+			res.setHeader(headerName, result)
+			next()
+		}
+	}
+}
+contentSecurityPolicy.getDefaultDirectives = getDefaultDirectives
+contentSecurityPolicy.dangerouslyDisableDefaultSrc = dangerouslyDisableDefaultSrc
+
+const ALLOWED_POLICIES$2 = new Set(["require-corp", "credentialless"])
+function getHeaderValueFromOptions$7({ policy = "require-corp" }) {
+	if (ALLOWED_POLICIES$2.has(policy)) {
+		return policy
+	} else {
+		throw new Error(`Cross-Origin-Embedder-Policy does not support the ${JSON.stringify(policy)} policy`)
+	}
+}
+function crossOriginEmbedderPolicy(options = {}) {
+	const headerValue = getHeaderValueFromOptions$7(options)
+	return function crossOriginEmbedderPolicyMiddleware(_req, res, next) {
+		res.setHeader("Cross-Origin-Embedder-Policy", headerValue)
+		next()
+	}
+}
+
+const ALLOWED_POLICIES$1 = new Set(["same-origin", "same-origin-allow-popups", "unsafe-none"])
+function getHeaderValueFromOptions$6({ policy = "same-origin" }) {
+	if (ALLOWED_POLICIES$1.has(policy)) {
+		return policy
+	} else {
+		throw new Error(`Cross-Origin-Opener-Policy does not support the ${JSON.stringify(policy)} policy`)
+	}
+}
+function crossOriginOpenerPolicy(options = {}) {
+	const headerValue = getHeaderValueFromOptions$6(options)
+	return function crossOriginOpenerPolicyMiddleware(_req, res, next) {
+		res.setHeader("Cross-Origin-Opener-Policy", headerValue)
+		next()
+	}
+}
+
+const ALLOWED_POLICIES = new Set(["same-origin", "same-site", "cross-origin"])
+function getHeaderValueFromOptions$5({ policy = "same-origin" }) {
+	if (ALLOWED_POLICIES.has(policy)) {
+		return policy
+	} else {
+		throw new Error(`Cross-Origin-Resource-Policy does not support the ${JSON.stringify(policy)} policy`)
+	}
+}
+function crossOriginResourcePolicy(options = {}) {
+	const headerValue = getHeaderValueFromOptions$5(options)
+	return function crossOriginResourcePolicyMiddleware(_req, res, next) {
+		res.setHeader("Cross-Origin-Resource-Policy", headerValue)
+		next()
+	}
+}
+
+function parseMaxAge$1(value = 0) {
+	if (value >= 0 && Number.isFinite(value)) {
+		return Math.floor(value)
+	} else {
+		throw new Error(`Expect-CT: ${JSON.stringify(value)} is not a valid value for maxAge. Please choose a positive integer.`)
+	}
+}
+function getHeaderValueFromOptions$4(options) {
+	const directives = [`max-age=${parseMaxAge$1(options.maxAge)}`]
+	if (options.enforce) {
+		directives.push("enforce")
+	}
+	if (options.reportUri) {
+		directives.push(`report-uri="${options.reportUri}"`)
+	}
+	return directives.join(", ")
+}
+function expectCt(options = {}) {
+	const headerValue = getHeaderValueFromOptions$4(options)
+	return function expectCtMiddleware(_req, res, next) {
+		res.setHeader("Expect-CT", headerValue)
+		next()
+	}
+}
+
+function originAgentCluster() {
+	return function originAgentClusterMiddleware(_req, res, next) {
+		res.setHeader("Origin-Agent-Cluster", "?1")
+		next()
+	}
+}
+
+const ALLOWED_TOKENS = new Set(["no-referrer", "no-referrer-when-downgrade", "same-origin", "origin", "strict-origin", "origin-when-cross-origin", "strict-origin-when-cross-origin", "unsafe-url", ""])
+function getHeaderValueFromOptions$3({ policy = ["no-referrer"] }) {
+	const tokens = typeof policy === "string" ? [policy] : policy
+	if (tokens.length === 0) {
+		throw new Error("Referrer-Policy received no policy tokens")
+	}
+	const tokensSeen = new Set()
+	tokens.forEach(token => {
+		if (!ALLOWED_TOKENS.has(token)) {
+			throw new Error(`Referrer-Policy received an unexpected policy token ${JSON.stringify(token)}`)
+		} else if (tokensSeen.has(token)) {
+			throw new Error(`Referrer-Policy received a duplicate policy token ${JSON.stringify(token)}`)
+		}
+		tokensSeen.add(token)
+	})
+	return tokens.join(",")
+}
+function referrerPolicy(options = {}) {
+	const headerValue = getHeaderValueFromOptions$3(options)
+	return function referrerPolicyMiddleware(_req, res, next) {
+		res.setHeader("Referrer-Policy", headerValue)
+		next()
+	}
+}
+
+const DEFAULT_MAX_AGE = 180 * 24 * 60 * 60
+function parseMaxAge(value = DEFAULT_MAX_AGE) {
+	if (value >= 0 && Number.isFinite(value)) {
+		return Math.floor(value)
+	} else {
+		throw new Error(`Strict-Transport-Security: ${JSON.stringify(value)} is not a valid value for maxAge. Please choose a positive integer.`)
+	}
+}
+function getHeaderValueFromOptions$2(options) {
+	if ("maxage" in options) {
+		throw new Error("Strict-Transport-Security received an unsupported property, `maxage`. Did you mean to pass `maxAge`?")
+	}
+	if ("includeSubdomains" in options) {
+		console.warn('Strict-Transport-Security middleware should use `includeSubDomains` instead of `includeSubdomains`. (The correct one has an uppercase "D".)')
+	}
+	if ("setIf" in options) {
+		console.warn("Strict-Transport-Security middleware no longer supports the `setIf` parameter. See the documentation and <https://github.com/helmetjs/helmet/wiki/Conditionally-using-middleware> if you need help replicating this behavior.")
+	}
+	const directives = [`max-age=${parseMaxAge(options.maxAge)}`]
+	if (options.includeSubDomains === undefined || options.includeSubDomains) {
+		directives.push("includeSubDomains")
+	}
+	if (options.preload) {
+		directives.push("preload")
+	}
+	return directives.join("; ")
+}
+function strictTransportSecurity(options = {}) {
+	const headerValue = getHeaderValueFromOptions$2(options)
+	return function strictTransportSecurityMiddleware(_req, res, next) {
+		res.setHeader("Strict-Transport-Security", headerValue)
+		next()
+	}
+}
+
+function xContentTypeOptions() {
+	return function xContentTypeOptionsMiddleware(_req, res, next) {
+		res.setHeader("X-Content-Type-Options", "nosniff")
+		next()
+	}
+}
+
+function xDnsPrefetchControl(options = {}) {
+	const headerValue = options.allow ? "on" : "off"
+	return function xDnsPrefetchControlMiddleware(_req, res, next) {
+		res.setHeader("X-DNS-Prefetch-Control", headerValue)
+		next()
+	}
+}
+
+function xDownloadOptions() {
+	return function xDownloadOptionsMiddleware(_req, res, next) {
+		res.setHeader("X-Download-Options", "noopen")
+		next()
+	}
+}
+
+function getHeaderValueFromOptions$1({ action = "sameorigin" }) {
+	const normalizedAction = typeof action === "string" ? action.toUpperCase() : action
+	switch (normalizedAction) {
+		case "SAME-ORIGIN":
+			return "SAMEORIGIN"
+		case "DENY":
+		case "SAMEORIGIN":
+			return normalizedAction
+		default:
+			throw new Error(`X-Frame-Options received an invalid action ${JSON.stringify(action)}`)
+	}
+}
+function xFrameOptions(options = {}) {
+	const headerValue = getHeaderValueFromOptions$1(options)
+	return function xFrameOptionsMiddleware(_req, res, next) {
+		res.setHeader("X-Frame-Options", headerValue)
+		next()
+	}
+}
+
+const ALLOWED_PERMITTED_POLICIES = new Set(["none", "master-only", "by-content-type", "all"])
+function getHeaderValueFromOptions({ permittedPolicies = "none" }) {
+	if (ALLOWED_PERMITTED_POLICIES.has(permittedPolicies)) {
+		return permittedPolicies
+	} else {
+		throw new Error(`X-Permitted-Cross-Domain-Policies does not support ${JSON.stringify(permittedPolicies)}`)
+	}
+}
+function xPermittedCrossDomainPolicies(options = {}) {
+	const headerValue = getHeaderValueFromOptions(options)
+	return function xPermittedCrossDomainPoliciesMiddleware(_req, res, next) {
+		res.setHeader("X-Permitted-Cross-Domain-Policies", headerValue)
+		next()
+	}
+}
+
+function xPoweredBy() {
+	return function xPoweredByMiddleware(_req, res, next) {
+		res.removeHeader("X-Powered-By")
+		next()
+	}
+}
+
+function xXssProtection() {
+	return function xXssProtectionMiddleware(_req, res, next) {
+		res.setHeader("X-XSS-Protection", "0")
+		next()
+	}
+}
+
+function getArgs(option, middlewareConfig = {}) {
+	switch (option) {
+		case undefined:
+		case true:
+			return []
+		case false:
+			return null
+		default:
+			if (middlewareConfig.takesOptions === false) {
+				console.warn(`${middlewareConfig.name} does not take options. Remove the property to silence this warning.`)
+				return []
+			} else {
+				return [option]
+			}
+	}
+}
+function getMiddlewareFunctionsFromOptions(options) {
+	const result = []
+	const contentSecurityPolicyArgs = getArgs(options.contentSecurityPolicy)
+	if (contentSecurityPolicyArgs) {
+		result.push(contentSecurityPolicy(...contentSecurityPolicyArgs))
+	}
+	const crossOriginEmbedderPolicyArgs = getArgs(options.crossOriginEmbedderPolicy)
+	if (crossOriginEmbedderPolicyArgs) {
+		result.push(crossOriginEmbedderPolicy(...crossOriginEmbedderPolicyArgs))
+	}
+	const crossOriginOpenerPolicyArgs = getArgs(options.crossOriginOpenerPolicy)
+	if (crossOriginOpenerPolicyArgs) {
+		result.push(crossOriginOpenerPolicy(...crossOriginOpenerPolicyArgs))
+	}
+	const crossOriginResourcePolicyArgs = getArgs(options.crossOriginResourcePolicy)
+	if (crossOriginResourcePolicyArgs) {
+		result.push(crossOriginResourcePolicy(...crossOriginResourcePolicyArgs))
+	}
+	const xDnsPrefetchControlArgs = getArgs(options.dnsPrefetchControl)
+	if (xDnsPrefetchControlArgs) {
+		result.push(xDnsPrefetchControl(...xDnsPrefetchControlArgs))
+	}
+	const expectCtArgs = options.expectCt && getArgs(options.expectCt)
+	if (expectCtArgs) {
+		result.push(expectCt(...expectCtArgs))
+	}
+	const xFrameOptionsArgs = getArgs(options.frameguard)
+	if (xFrameOptionsArgs) {
+		result.push(xFrameOptions(...xFrameOptionsArgs))
+	}
+	const xPoweredByArgs = getArgs(options.hidePoweredBy, {
+		name: "hidePoweredBy",
+		takesOptions: false
+	})
+	if (xPoweredByArgs) {
+		result.push(xPoweredBy())
+	}
+	const strictTransportSecurityArgs = getArgs(options.hsts)
+	if (strictTransportSecurityArgs) {
+		result.push(strictTransportSecurity(...strictTransportSecurityArgs))
+	}
+	const xDownloadOptionsArgs = getArgs(options.ieNoOpen, {
+		name: "ieNoOpen",
+		takesOptions: false
+	})
+	if (xDownloadOptionsArgs) {
+		result.push(xDownloadOptions())
+	}
+	const xContentTypeOptionsArgs = getArgs(options.noSniff, {
+		name: "noSniff",
+		takesOptions: false
+	})
+	if (xContentTypeOptionsArgs) {
+		result.push(xContentTypeOptions())
+	}
+	const originAgentClusterArgs = getArgs(options.originAgentCluster, {
+		name: "originAgentCluster",
+		takesOptions: false
+	})
+	if (originAgentClusterArgs) {
+		result.push(originAgentCluster())
+	}
+	const xPermittedCrossDomainPoliciesArgs = getArgs(options.permittedCrossDomainPolicies)
+	if (xPermittedCrossDomainPoliciesArgs) {
+		result.push(xPermittedCrossDomainPolicies(...xPermittedCrossDomainPoliciesArgs))
+	}
+	const referrerPolicyArgs = getArgs(options.referrerPolicy)
+	if (referrerPolicyArgs) {
+		result.push(referrerPolicy(...referrerPolicyArgs))
+	}
+	const xXssProtectionArgs = getArgs(options.xssFilter, {
+		name: "xssFilter",
+		takesOptions: false
+	})
+	if (xXssProtectionArgs) {
+		result.push(xXssProtection())
+	}
+	return result
+}
+const helmet = Object.assign(
+	function helmet(options = {}) {
+		var _a
+		if (((_a = options.constructor) === null || _a === void 0 ? void 0 : _a.name) === "IncomingMessage") {
+			throw new Error("It appears you have done something like `app.use(helmet)`, but it should be `app.use(helmet())`.")
+		}
+		const middlewareFunctions = getMiddlewareFunctionsFromOptions(options)
+		return function helmetMiddleware(req, res, next) {
+			let middlewareIndex = 0
+			;(function internalNext(err) {
+				if (err) {
+					next(err)
+					return
+				}
+				const middlewareFunction = middlewareFunctions[middlewareIndex]
+				if (middlewareFunction) {
+					middlewareIndex++
+					middlewareFunction(req, res, internalNext)
+				} else {
+					next()
+				}
+			})()
+		}
+	},
+	{
+		contentSecurityPolicy,
+		crossOriginEmbedderPolicy,
+		crossOriginOpenerPolicy,
+		crossOriginResourcePolicy,
+		dnsPrefetchControl: xDnsPrefetchControl,
+		expectCt,
+		frameguard: xFrameOptions,
+		hidePoweredBy: xPoweredBy,
+		hsts: strictTransportSecurity,
+		ieNoOpen: xDownloadOptions,
+		noSniff: xContentTypeOptions,
+		originAgentCluster,
+		permittedCrossDomainPolicies: xPermittedCrossDomainPolicies,
+		referrerPolicy,
+		xssFilter: xXssProtection
+	}
+)
+
+export { contentSecurityPolicy, crossOriginEmbedderPolicy, crossOriginOpenerPolicy, crossOriginResourcePolicy, helmet as default, xDnsPrefetchControl as dnsPrefetchControl, expectCt, xFrameOptions as frameguard, xPoweredBy as hidePoweredBy, strictTransportSecurity as hsts, xDownloadOptions as ieNoOpen, xContentTypeOptions as noSniff, originAgentCluster, xPermittedCrossDomainPolicies as permittedCrossDomainPolicies, referrerPolicy, xXssProtection as xssFilter }

--- a/backend/node_modules/helmet/dist/types/index.d.ts
+++ b/backend/node_modules/helmet/dist/types/index.d.ts
@@ -1,0 +1,55 @@
+/// <reference types="node" />
+import { IncomingMessage, ServerResponse } from "http"
+import contentSecurityPolicy, { ContentSecurityPolicyOptions } from "./middlewares/content-security-policy/index.js"
+import crossOriginEmbedderPolicy, { CrossOriginEmbedderPolicyOptions } from "./middlewares/cross-origin-embedder-policy/index.js"
+import crossOriginOpenerPolicy, { CrossOriginOpenerPolicyOptions } from "./middlewares/cross-origin-opener-policy/index.js"
+import crossOriginResourcePolicy, { CrossOriginResourcePolicyOptions } from "./middlewares/cross-origin-resource-policy/index.js"
+import expectCt, { ExpectCtOptions } from "./middlewares/expect-ct/index.js"
+import originAgentCluster from "./middlewares/origin-agent-cluster/index.js"
+import referrerPolicy, { ReferrerPolicyOptions } from "./middlewares/referrer-policy/index.js"
+import strictTransportSecurity, { StrictTransportSecurityOptions } from "./middlewares/strict-transport-security/index.js"
+import xContentTypeOptions from "./middlewares/x-content-type-options/index.js"
+import xDnsPrefetchControl, { XDnsPrefetchControlOptions } from "./middlewares/x-dns-prefetch-control/index.js"
+import xDownloadOptions from "./middlewares/x-download-options/index.js"
+import xFrameOptions, { XFrameOptionsOptions } from "./middlewares/x-frame-options/index.js"
+import xPermittedCrossDomainPolicies, { XPermittedCrossDomainPoliciesOptions } from "./middlewares/x-permitted-cross-domain-policies/index.js"
+import xPoweredBy from "./middlewares/x-powered-by/index.js"
+import xXssProtection from "./middlewares/x-xss-protection/index.js"
+export interface HelmetOptions {
+	contentSecurityPolicy?: ContentSecurityPolicyOptions | boolean
+	crossOriginEmbedderPolicy?: CrossOriginEmbedderPolicyOptions | boolean
+	crossOriginOpenerPolicy?: CrossOriginOpenerPolicyOptions | boolean
+	crossOriginResourcePolicy?: CrossOriginResourcePolicyOptions | boolean
+	dnsPrefetchControl?: XDnsPrefetchControlOptions | boolean
+	expectCt?: ExpectCtOptions | boolean
+	frameguard?: XFrameOptionsOptions | boolean
+	hidePoweredBy?: boolean
+	hsts?: StrictTransportSecurityOptions | boolean
+	ieNoOpen?: boolean
+	noSniff?: boolean
+	originAgentCluster?: boolean
+	permittedCrossDomainPolicies?: XPermittedCrossDomainPoliciesOptions | boolean
+	referrerPolicy?: ReferrerPolicyOptions | boolean
+	xssFilter?: boolean
+}
+interface Helmet {
+	(options?: Readonly<HelmetOptions>): (req: IncomingMessage, res: ServerResponse, next: (err?: unknown) => void) => void
+	contentSecurityPolicy: typeof contentSecurityPolicy
+	crossOriginEmbedderPolicy: typeof crossOriginEmbedderPolicy
+	crossOriginOpenerPolicy: typeof crossOriginOpenerPolicy
+	crossOriginResourcePolicy: typeof crossOriginResourcePolicy
+	dnsPrefetchControl: typeof xDnsPrefetchControl
+	expectCt: typeof expectCt
+	frameguard: typeof xFrameOptions
+	hidePoweredBy: typeof xPoweredBy
+	hsts: typeof strictTransportSecurity
+	ieNoOpen: typeof xDownloadOptions
+	noSniff: typeof xContentTypeOptions
+	originAgentCluster: typeof originAgentCluster
+	permittedCrossDomainPolicies: typeof xPermittedCrossDomainPolicies
+	referrerPolicy: typeof referrerPolicy
+	xssFilter: typeof xXssProtection
+}
+declare const helmet: Helmet
+export default helmet
+export { contentSecurityPolicy, crossOriginEmbedderPolicy, crossOriginOpenerPolicy, crossOriginResourcePolicy, expectCt, originAgentCluster, referrerPolicy, strictTransportSecurity as hsts, xContentTypeOptions as noSniff, xDnsPrefetchControl as dnsPrefetchControl, xDownloadOptions as ieNoOpen, xFrameOptions as frameguard, xPermittedCrossDomainPolicies as permittedCrossDomainPolicies, xPoweredBy as hidePoweredBy, xXssProtection as xssFilter }

--- a/backend/node_modules/helmet/dist/types/middlewares/content-security-policy/index.d.ts
+++ b/backend/node_modules/helmet/dist/types/middlewares/content-security-policy/index.d.ts
@@ -1,0 +1,23 @@
+/// <reference types="node" />
+import { IncomingMessage, ServerResponse } from "http"
+interface ContentSecurityPolicyDirectiveValueFunction {
+	(req: IncomingMessage, res: ServerResponse): string
+}
+declare type ContentSecurityPolicyDirectiveValue = string | ContentSecurityPolicyDirectiveValueFunction
+export interface ContentSecurityPolicyOptions {
+	useDefaults?: boolean
+	directives?: Record<string, null | Iterable<ContentSecurityPolicyDirectiveValue> | typeof dangerouslyDisableDefaultSrc>
+	reportOnly?: boolean
+}
+interface ContentSecurityPolicy {
+	(options?: Readonly<ContentSecurityPolicyOptions>): (req: IncomingMessage, res: ServerResponse, next: (err?: Error) => void) => void
+	getDefaultDirectives: typeof getDefaultDirectives
+	dangerouslyDisableDefaultSrc: typeof dangerouslyDisableDefaultSrc
+}
+declare const dangerouslyDisableDefaultSrc: unique symbol
+declare const getDefaultDirectives: () => {
+	[x: string]: Iterable<ContentSecurityPolicyDirectiveValue>
+}
+declare const contentSecurityPolicy: ContentSecurityPolicy
+export default contentSecurityPolicy
+export { getDefaultDirectives, dangerouslyDisableDefaultSrc }

--- a/backend/node_modules/helmet/dist/types/middlewares/cross-origin-embedder-policy/index.d.ts
+++ b/backend/node_modules/helmet/dist/types/middlewares/cross-origin-embedder-policy/index.d.ts
@@ -1,0 +1,6 @@
+import { IncomingMessage, ServerResponse } from "http"
+export interface CrossOriginEmbedderPolicyOptions {
+	policy?: "require-corp" | "credentialless"
+}
+declare function crossOriginEmbedderPolicy(options?: Readonly<CrossOriginEmbedderPolicyOptions>): (_req: IncomingMessage, res: ServerResponse, next: () => void) => void
+export default crossOriginEmbedderPolicy

--- a/backend/node_modules/helmet/dist/types/middlewares/cross-origin-opener-policy/index.d.ts
+++ b/backend/node_modules/helmet/dist/types/middlewares/cross-origin-opener-policy/index.d.ts
@@ -1,0 +1,6 @@
+import { IncomingMessage, ServerResponse } from "http"
+export interface CrossOriginOpenerPolicyOptions {
+	policy?: "same-origin" | "same-origin-allow-popups" | "unsafe-none"
+}
+declare function crossOriginOpenerPolicy(options?: Readonly<CrossOriginOpenerPolicyOptions>): (_req: IncomingMessage, res: ServerResponse, next: () => void) => void
+export default crossOriginOpenerPolicy

--- a/backend/node_modules/helmet/dist/types/middlewares/cross-origin-resource-policy/index.d.ts
+++ b/backend/node_modules/helmet/dist/types/middlewares/cross-origin-resource-policy/index.d.ts
@@ -1,0 +1,6 @@
+import { IncomingMessage, ServerResponse } from "http"
+export interface CrossOriginResourcePolicyOptions {
+	policy?: "same-origin" | "same-site" | "cross-origin"
+}
+declare function crossOriginResourcePolicy(options?: Readonly<CrossOriginResourcePolicyOptions>): (_req: IncomingMessage, res: ServerResponse, next: () => void) => void
+export default crossOriginResourcePolicy

--- a/backend/node_modules/helmet/dist/types/middlewares/expect-ct/index.d.ts
+++ b/backend/node_modules/helmet/dist/types/middlewares/expect-ct/index.d.ts
@@ -1,0 +1,8 @@
+import { IncomingMessage, ServerResponse } from "http"
+export interface ExpectCtOptions {
+	maxAge?: number
+	enforce?: boolean
+	reportUri?: string
+}
+declare function expectCt(options?: Readonly<ExpectCtOptions>): (_req: IncomingMessage, res: ServerResponse, next: () => void) => void
+export default expectCt

--- a/backend/node_modules/helmet/dist/types/middlewares/origin-agent-cluster/index.d.ts
+++ b/backend/node_modules/helmet/dist/types/middlewares/origin-agent-cluster/index.d.ts
@@ -1,0 +1,3 @@
+import { IncomingMessage, ServerResponse } from "http"
+declare function originAgentCluster(): (_req: IncomingMessage, res: ServerResponse, next: () => void) => void
+export default originAgentCluster

--- a/backend/node_modules/helmet/dist/types/middlewares/referrer-policy/index.d.ts
+++ b/backend/node_modules/helmet/dist/types/middlewares/referrer-policy/index.d.ts
@@ -1,0 +1,7 @@
+import { IncomingMessage, ServerResponse } from "http"
+declare type ReferrerPolicyToken = "no-referrer" | "no-referrer-when-downgrade" | "same-origin" | "origin" | "strict-origin" | "origin-when-cross-origin" | "strict-origin-when-cross-origin" | "unsafe-url" | ""
+export interface ReferrerPolicyOptions {
+	policy?: ReferrerPolicyToken | ReferrerPolicyToken[]
+}
+declare function referrerPolicy(options?: Readonly<ReferrerPolicyOptions>): (_req: IncomingMessage, res: ServerResponse, next: () => void) => void
+export default referrerPolicy

--- a/backend/node_modules/helmet/dist/types/middlewares/strict-transport-security/index.d.ts
+++ b/backend/node_modules/helmet/dist/types/middlewares/strict-transport-security/index.d.ts
@@ -1,0 +1,8 @@
+import { IncomingMessage, ServerResponse } from "http"
+export interface StrictTransportSecurityOptions {
+	maxAge?: number
+	includeSubDomains?: boolean
+	preload?: boolean
+}
+declare function strictTransportSecurity(options?: Readonly<StrictTransportSecurityOptions>): (_req: IncomingMessage, res: ServerResponse, next: () => void) => void
+export default strictTransportSecurity

--- a/backend/node_modules/helmet/dist/types/middlewares/x-content-type-options/index.d.ts
+++ b/backend/node_modules/helmet/dist/types/middlewares/x-content-type-options/index.d.ts
@@ -1,0 +1,3 @@
+import { IncomingMessage, ServerResponse } from "http"
+declare function xContentTypeOptions(): (_req: IncomingMessage, res: ServerResponse, next: () => void) => void
+export default xContentTypeOptions

--- a/backend/node_modules/helmet/dist/types/middlewares/x-dns-prefetch-control/index.d.ts
+++ b/backend/node_modules/helmet/dist/types/middlewares/x-dns-prefetch-control/index.d.ts
@@ -1,0 +1,6 @@
+import { IncomingMessage, ServerResponse } from "http"
+export interface XDnsPrefetchControlOptions {
+	allow?: boolean
+}
+declare function xDnsPrefetchControl(options?: Readonly<XDnsPrefetchControlOptions>): (_req: IncomingMessage, res: ServerResponse, next: () => void) => void
+export default xDnsPrefetchControl

--- a/backend/node_modules/helmet/dist/types/middlewares/x-download-options/index.d.ts
+++ b/backend/node_modules/helmet/dist/types/middlewares/x-download-options/index.d.ts
@@ -1,0 +1,3 @@
+import { IncomingMessage, ServerResponse } from "http"
+declare function xDownloadOptions(): (_req: IncomingMessage, res: ServerResponse, next: () => void) => void
+export default xDownloadOptions

--- a/backend/node_modules/helmet/dist/types/middlewares/x-frame-options/index.d.ts
+++ b/backend/node_modules/helmet/dist/types/middlewares/x-frame-options/index.d.ts
@@ -1,0 +1,6 @@
+import { IncomingMessage, ServerResponse } from "http"
+export interface XFrameOptionsOptions {
+	action?: "deny" | "sameorigin"
+}
+declare function xFrameOptions(options?: Readonly<XFrameOptionsOptions>): (_req: IncomingMessage, res: ServerResponse, next: () => void) => void
+export default xFrameOptions

--- a/backend/node_modules/helmet/dist/types/middlewares/x-permitted-cross-domain-policies/index.d.ts
+++ b/backend/node_modules/helmet/dist/types/middlewares/x-permitted-cross-domain-policies/index.d.ts
@@ -1,0 +1,6 @@
+import { IncomingMessage, ServerResponse } from "http"
+export interface XPermittedCrossDomainPoliciesOptions {
+	permittedPolicies?: "none" | "master-only" | "by-content-type" | "all"
+}
+declare function xPermittedCrossDomainPolicies(options?: Readonly<XPermittedCrossDomainPoliciesOptions>): (_req: IncomingMessage, res: ServerResponse, next: () => void) => void
+export default xPermittedCrossDomainPolicies

--- a/backend/node_modules/helmet/dist/types/middlewares/x-powered-by/index.d.ts
+++ b/backend/node_modules/helmet/dist/types/middlewares/x-powered-by/index.d.ts
@@ -1,0 +1,3 @@
+import { IncomingMessage, ServerResponse } from "http"
+declare function xPoweredBy(): (_req: IncomingMessage, res: ServerResponse, next: () => void) => void
+export default xPoweredBy

--- a/backend/node_modules/helmet/dist/types/middlewares/x-xss-protection/index.d.ts
+++ b/backend/node_modules/helmet/dist/types/middlewares/x-xss-protection/index.d.ts
@@ -1,0 +1,3 @@
+import { IncomingMessage, ServerResponse } from "http"
+declare function xXssProtection(): (_req: IncomingMessage, res: ServerResponse, next: () => void) => void
+export default xXssProtection

--- a/backend/node_modules/helmet/package.json
+++ b/backend/node_modules/helmet/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "helmet",
+  "author": "Adam Baldwin <adam@npmjs.com> (https://evilpacket.net)",
+  "contributors": [
+    "Evan Hahn <me@evanhahn.com> (https://evanhahn.com)",
+    "Ameen Abdeen <ameen.abdeen.se@gmail.com>"
+  ],
+  "description": "help secure Express/Connect apps with various HTTP headers",
+  "version": "6.0.1",
+  "keywords": [
+    "express",
+    "security",
+    "headers",
+    "backend"
+  ],
+  "homepage": "https://helmetjs.github.io/",
+  "bugs": {
+    "url": "https://github.com/helmetjs/helmet/issues",
+    "email": "me@evanhahn.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/helmetjs/helmet.git"
+  },
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "devDependencies": {
+    "@rollup/plugin-typescript": "^8.3.3",
+    "@types/connect": "^3.4.35",
+    "@types/jest": "^28.1.6",
+    "@types/supertest": "^2.0.12",
+    "@typescript-eslint/eslint-plugin": "^5.30.7",
+    "@typescript-eslint/parser": "^5.30.7",
+    "connect": "^3.7.0",
+    "eslint": "^8.20.0",
+    "jest": "^28.1.3",
+    "prettier": "^2.7.1",
+    "rollup": "^2.77.0",
+    "supertest": "^6.2.4",
+    "ts-jest": "^28.0.7",
+    "typescript": "^4.7.4"
+  },
+  "scripts": {
+    "pretest": "npm run lint",
+    "prepublishOnly": "npm run build-helmet",
+    "lint": "npm run lint:eslint && npm run lint:prettier",
+    "lint:eslint": "eslint .",
+    "lint:prettier": "prettier --check .",
+    "format": "prettier --write .",
+    "clean": "node ./bin/clean.js",
+    "build-helmet": "npm run clean && node ./bin/build-helmet.js && prettier --write --config .prettierrc-dist.cjs --ignore-path /dev/null dist",
+    "build-middleware-package": "npm run clean && tsc --emitDeclarationOnly -p tsconfig-types.json && node ./bin/build-middleware-package.js",
+    "test": "jest"
+  },
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts"
+    }
+  }
+}

--- a/backend/node_modules/object-assign/index.js
+++ b/backend/node_modules/object-assign/index.js
@@ -1,0 +1,90 @@
+/*
+object-assign
+(c) Sindre Sorhus
+@license MIT
+*/
+
+'use strict';
+/* eslint-disable no-unused-vars */
+var getOwnPropertySymbols = Object.getOwnPropertySymbols;
+var hasOwnProperty = Object.prototype.hasOwnProperty;
+var propIsEnumerable = Object.prototype.propertyIsEnumerable;
+
+function toObject(val) {
+	if (val === null || val === undefined) {
+		throw new TypeError('Object.assign cannot be called with null or undefined');
+	}
+
+	return Object(val);
+}
+
+function shouldUseNative() {
+	try {
+		if (!Object.assign) {
+			return false;
+		}
+
+		// Detect buggy property enumeration order in older V8 versions.
+
+		// https://bugs.chromium.org/p/v8/issues/detail?id=4118
+		var test1 = new String('abc');  // eslint-disable-line no-new-wrappers
+		test1[5] = 'de';
+		if (Object.getOwnPropertyNames(test1)[0] === '5') {
+			return false;
+		}
+
+		// https://bugs.chromium.org/p/v8/issues/detail?id=3056
+		var test2 = {};
+		for (var i = 0; i < 10; i++) {
+			test2['_' + String.fromCharCode(i)] = i;
+		}
+		var order2 = Object.getOwnPropertyNames(test2).map(function (n) {
+			return test2[n];
+		});
+		if (order2.join('') !== '0123456789') {
+			return false;
+		}
+
+		// https://bugs.chromium.org/p/v8/issues/detail?id=3056
+		var test3 = {};
+		'abcdefghijklmnopqrst'.split('').forEach(function (letter) {
+			test3[letter] = letter;
+		});
+		if (Object.keys(Object.assign({}, test3)).join('') !==
+				'abcdefghijklmnopqrst') {
+			return false;
+		}
+
+		return true;
+	} catch (err) {
+		// We don't expect any of the above to throw, but better to be safe.
+		return false;
+	}
+}
+
+module.exports = shouldUseNative() ? Object.assign : function (target, source) {
+	var from;
+	var to = toObject(target);
+	var symbols;
+
+	for (var s = 1; s < arguments.length; s++) {
+		from = Object(arguments[s]);
+
+		for (var key in from) {
+			if (hasOwnProperty.call(from, key)) {
+				to[key] = from[key];
+			}
+		}
+
+		if (getOwnPropertySymbols) {
+			symbols = getOwnPropertySymbols(from);
+			for (var i = 0; i < symbols.length; i++) {
+				if (propIsEnumerable.call(from, symbols[i])) {
+					to[symbols[i]] = from[symbols[i]];
+				}
+			}
+		}
+	}
+
+	return to;
+};

--- a/backend/node_modules/object-assign/license
+++ b/backend/node_modules/object-assign/license
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/backend/node_modules/object-assign/package.json
+++ b/backend/node_modules/object-assign/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "object-assign",
+  "version": "4.1.1",
+  "description": "ES2015 `Object.assign()` ponyfill",
+  "license": "MIT",
+  "repository": "sindresorhus/object-assign",
+  "author": {
+    "name": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com"
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "scripts": {
+    "test": "xo && ava",
+    "bench": "matcha bench.js"
+  },
+  "files": [
+    "index.js"
+  ],
+  "keywords": [
+    "object",
+    "assign",
+    "extend",
+    "properties",
+    "es2015",
+    "ecmascript",
+    "harmony",
+    "ponyfill",
+    "prollyfill",
+    "polyfill",
+    "shim",
+    "browser"
+  ],
+  "devDependencies": {
+    "ava": "^0.16.0",
+    "lodash": "^4.16.4",
+    "matcha": "^0.7.0",
+    "xo": "^0.16.0"
+  }
+}

--- a/backend/node_modules/object-assign/readme.md
+++ b/backend/node_modules/object-assign/readme.md
@@ -1,0 +1,61 @@
+# object-assign [![Build Status](https://travis-ci.org/sindresorhus/object-assign.svg?branch=master)](https://travis-ci.org/sindresorhus/object-assign)
+
+> ES2015 [`Object.assign()`](http://www.2ality.com/2014/01/object-assign.html) [ponyfill](https://ponyfill.com)
+
+
+## Use the built-in
+
+Node.js 4 and up, as well as every evergreen browser (Chrome, Edge, Firefox, Opera, Safari),
+support `Object.assign()` :tada:. If you target only those environments, then by all
+means, use `Object.assign()` instead of this package.
+
+
+## Install
+
+```
+$ npm install --save object-assign
+```
+
+
+## Usage
+
+```js
+const objectAssign = require('object-assign');
+
+objectAssign({foo: 0}, {bar: 1});
+//=> {foo: 0, bar: 1}
+
+// multiple sources
+objectAssign({foo: 0}, {bar: 1}, {baz: 2});
+//=> {foo: 0, bar: 1, baz: 2}
+
+// overwrites equal keys
+objectAssign({foo: 0}, {foo: 1}, {foo: 2});
+//=> {foo: 2}
+
+// ignores null and undefined sources
+objectAssign({foo: 0}, null, {bar: 1}, undefined);
+//=> {foo: 0, bar: 1}
+```
+
+
+## API
+
+### objectAssign(target, [source, ...])
+
+Assigns enumerable own properties of `source` objects to the `target` object and returns the `target` object. Additional `source` objects will overwrite previous ones.
+
+
+## Resources
+
+- [ES2015 spec - Object.assign](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object.assign)
+
+
+## Related
+
+- [deep-assign](https://github.com/sindresorhus/deep-assign) - Recursive `Object.assign()`
+
+
+## License
+
+MIT © [Sindre Sorhus](https://sindresorhus.com)

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "express": "^4.18.2"
+        "cors": "^2.8.5",
+        "express": "^4.18.2",
+        "helmet": "^6.0.1"
       }
     },
     "node_modules/accepts": {
@@ -103,6 +105,18 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -269,6 +283,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/helmet": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-6.0.1.tgz",
+      "integrity": "sha512-8wo+VdQhTMVBMCITYZaGTbE4lvlthelPYSvoyNvk4RECTmrVjMerp9RfUOQXZWLvCcAn1pKj7ZRxK4lI9Alrcw==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -370,6 +392,14 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -660,6 +690,15 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -788,6 +827,11 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
     },
+    "helmet": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-6.0.1.tgz",
+      "integrity": "sha512-8wo+VdQhTMVBMCITYZaGTbE4lvlthelPYSvoyNvk4RECTmrVjMerp9RfUOQXZWLvCcAn1pKj7ZRxK4lI9Alrcw=="
+    },
     "http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -860,6 +904,11 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
     },
     "object-inspect": {
       "version": "1.12.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,6 +10,8 @@
   "author": "Bruno Costa",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.18.2"
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "helmet": "^6.0.1"
   }
 }

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,16 +1,20 @@
 const express = require("express");
 const cors = require("cors");
+const helmet = require("helmet");
 const app = express();
 const port = 3000;
 
 app.use(cors());
+app.use(helmet());
+app.use(express.json());
 
 app.get("/events", (req, res) => {
-  const events = require("./sportData.json");
-  console.log(events)
-  res.json(events);
+    const events = require("./sportData.json");
+    console.log(events)
+    res.json(events);
 });
 
 app.listen(port, () => {
-  console.log(`Server listening at http://localhost:${port}`);
+    console.log(`Server listening at http://localhost:${port}`);
 });
+

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "axios": "^1.2.3",
         "core-js": "^3.8.3",
         "vue": "^3.2.13",
         "vue-router": "^4.0.3",
@@ -4217,8 +4218,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmmirror.com/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -4250,6 +4250,29 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.3.tgz",
+      "integrity": "sha512-pdDkMYJeuXLZ6Xj/Q5J3Phpe+jbGdsSzlQaFVkMQzRUL05+6+tetX8TV3p4HrU4kzuO9bt+io/yGQxuyxA/xcw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/babel-jest": {
@@ -5055,7 +5078,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmmirror.com/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -5838,7 +5860,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmmirror.com/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -6599,7 +6620,6 @@
       "version": "1.15.2",
       "resolved": "https://registry.npmmirror.com/follow-redirects/-/follow-redirects-1.15.2.tgz",
       "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
-      "dev": true,
       "engines": {
         "node": ">=4.0"
       },
@@ -10451,7 +10471,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmmirror.com/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -10460,7 +10479,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmmirror.com/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -11965,6 +11983,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pseudomap": {
       "version": "1.0.2",
@@ -16908,7 +16931,8 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmmirror.com/@vue/cli-plugin-vuex/-/cli-plugin-vuex-5.0.8.tgz",
       "integrity": "sha512-HSYWPqrunRE5ZZs8kVwiY6oWcn95qf/OQabwLfprhdpFWAGtLStShjsGED2aDpSSeGAskQETrtR/5h7VqgIlBA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@vue/cli-service": {
       "version": "5.0.8",
@@ -17233,7 +17257,8 @@
       "version": "2.2.7",
       "resolved": "https://registry.npmmirror.com/@vue/test-utils/-/test-utils-2.2.7.tgz",
       "integrity": "sha512-BMuoruUFTEqhLoOgsMcgNVMiByYbfHCKGr2C4CPdGtz/affUtDVX5zr1RnPuq0tYSiaqq+Enw5voUpG6JY8Q7g==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@vue/vue-loader-v15": {
       "version": "npm:vue-loader@15.10.1",
@@ -17514,7 +17539,8 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmmirror.com/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
       "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "8.2.0",
@@ -17582,7 +17608,8 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmmirror.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -17669,8 +17696,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmmirror.com/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -17690,6 +17716,28 @@
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
         "postcss-value-parser": "^4.2.0"
+      }
+    },
+    "axios": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.3.tgz",
+      "integrity": "sha512-pdDkMYJeuXLZ6Xj/Q5J3Phpe+jbGdsSzlQaFVkMQzRUL05+6+tetX8TV3p4HrU4kzuO9bt+io/yGQxuyxA/xcw==",
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "babel-jest": {
@@ -18351,7 +18399,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmmirror.com/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -18575,7 +18622,8 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmmirror.com/css-declaration-sorter/-/css-declaration-sorter-6.3.1.tgz",
       "integrity": "sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "css-loader": {
       "version": "6.7.3",
@@ -18761,7 +18809,8 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmmirror.com/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
       "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "csso": {
       "version": "4.2.0",
@@ -18962,8 +19011,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmmirror.com/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "depd": {
       "version": "2.0.0",
@@ -19595,8 +19643,7 @@
     "follow-redirects": {
       "version": "1.15.2",
       "resolved": "https://registry.npmmirror.com/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
-      "dev": true
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "form-data": {
       "version": "3.0.1",
@@ -20026,7 +20073,8 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmmirror.com/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ieee754": {
       "version": "1.2.1",
@@ -21096,7 +21144,8 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmmirror.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "27.5.1",
@@ -22638,14 +22687,12 @@
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmmirror.com/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmmirror.com/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "requires": {
         "mime-db": "1.52.0"
       }
@@ -23361,25 +23408,29 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmmirror.com/postcss-discard-comments/-/postcss-discard-comments-5.1.2.tgz",
       "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-duplicates": {
       "version": "5.1.0",
       "resolved": "https://registry.npmmirror.com/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
       "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-empty": {
       "version": "5.1.1",
       "resolved": "https://registry.npmmirror.com/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
       "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-overridden": {
       "version": "5.1.0",
       "resolved": "https://registry.npmmirror.com/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
       "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-loader": {
       "version": "6.2.1",
@@ -23484,7 +23535,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmmirror.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
       "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -23519,7 +23571,8 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmmirror.com/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
       "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-normalize-display-values": {
       "version": "5.1.0",
@@ -23762,6 +23815,11 @@
           "dev": true
         }
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -25526,7 +25584,8 @@
           "version": "8.12.0",
           "resolved": "https://registry.npmmirror.com/ws/-/ws-8.12.0.tgz",
           "integrity": "sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -25681,7 +25740,8 @@
       "version": "7.5.9",
       "resolved": "https://registry.npmmirror.com/ws/-/ws-7.5.9.tgz",
       "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "test:unit": "jest"
   },
   "dependencies": {
+    "axios": "^1.2.3",
     "core-js": "^3.8.3",
     "vue": "^3.2.13",
     "vue-router": "^4.0.3",


### PR DESCRIPTION
### 🚧 Todo

🛡 Increase security of `server.js`:

- the `helmet()` middleware is used to add security-related `HTTP` headers to the response.
- the `express.json()` middleware is used to parse incoming JSON payloads.

The JSON file is imported only when the `/events` route is hit, rather than when the file is imported.