### PR TITLE
Add heading to HomeView.vue

### DIFF
--- a/frontend/src/components/UI/Heading.vue
+++ b/frontend/src/components/UI/Heading.vue
@@ -1,0 +1,25 @@
+<template>
+  <div>
+    <h1>{{ heading }}</h1>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "Heading",
+  data() {
+    return {
+      heading: "Sports Events Calendar",
+    };
+  },
+};
+</script>
+
+<style scoped>
+h1 {
+  color: rgb(102, 215, 129);
+  font-size: 36px;
+  text-transform: uppercase;
+  text-shadow: 2px 2px #ccc;
+}
+</style>

--- a/frontend/src/views/AboutView.vue
+++ b/frontend/src/views/AboutView.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="about">
-    <h1>Sports Events Calendar</h1>
     <p>
       This application shows data from sports events fetched from a backend of
       JSON data. It was built using Vue 3, Vuex, NodeJS and ExpressJS.

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="home">
+    <Heading />
     <Calendar @event-added="fetchEvents" />
   </div>
 </template>
@@ -7,11 +8,13 @@
 <script>
 // @ is an alias to /src
 import { mapActions } from "vuex";
+import Heading from "@/components/UI/Heading.vue";
 import Calendar from "@/components/CalendarComponent.vue";
 
 export default {
   name: "HomeView",
   components: {
+    Heading,
     Calendar,
   },
   methods: {


### PR DESCRIPTION
### 🚧 Todo 

- create a reusable component that is used to display a `heading`. It takes in `props` text and size of the heading and renders it in the template using template syntax.
- import `Heading.vue` to `HomeView.vue`.